### PR TITLE
Fixing Activity Tab returning 0 results

### DIFF
--- a/src/Squidex/Config/Domain/StoreMongoDbModule.cs
+++ b/src/Squidex/Config/Domain/StoreMongoDbModule.cs
@@ -115,6 +115,7 @@ namespace Squidex.Config.Domain
             builder.RegisterType<MongoHistoryEventRepository>()
                 .WithParameter(ResolvedParameter.ForNamed<IMongoDatabase>(MongoDatabaseRegistration))
                 .As<IHistoryEventRepository>()
+                .As<IEventConsumer>()
                 .As<IExternalSystem>()
                 .AsSelf()
                 .SingleInstance();


### PR DESCRIPTION
MongoHistoryEventRespository had IEventConsumer service removed from it's AutoFac registration.
Resolves issue #99 