### PR TITLE
Migration of profile controller to asp.net core 2.0

### DIFF
--- a/src/Squidex/Controllers/UI/Profile/ProfileController.cs
+++ b/src/Squidex/Controllers/UI/Profile/ProfileController.cs
@@ -34,19 +34,16 @@ namespace Squidex.Controllers.UI.Profile
         private readonly IUserPictureStore userPictureStore;
         private readonly IAssetThumbnailGenerator assetThumbnailGenerator;
         private readonly IOptions<MyIdentityOptions> identityOptions;
-        private readonly IOptions<IdentityCookieOptions> identityCookieOptions;
 
         public ProfileController(
             SignInManager<IUser> signInManager,
             UserManager<IUser> userManager,
             IUserPictureStore userPictureStore,
             IAssetThumbnailGenerator assetThumbnailGenerator,
-            IOptions<MyIdentityOptions> identityOptions,
-            IOptions<IdentityCookieOptions> identityCookieOptions)
+            IOptions<MyIdentityOptions> identityOptions)
         {
             this.signInManager = signInManager;
             this.identityOptions = identityOptions;
-            this.identityCookieOptions = identityCookieOptions;
             this.userManager = userManager;
             this.userPictureStore = userPictureStore;
             this.assetThumbnailGenerator = assetThumbnailGenerator;
@@ -65,7 +62,7 @@ namespace Squidex.Controllers.UI.Profile
         [Route("/account/profile/login-add/")]
         public async Task<IActionResult> AddLogin(string provider)
         {
-            await HttpContext.Authentication.SignOutAsync(identityCookieOptions.Value.ExternalCookieAuthenticationScheme);
+            await HttpContext.Authentication.SignOutAsync(IdentityConstants.ExternalScheme);
 
             var properties =
                 signInManager.ConfigureExternalAuthenticationProperties(provider,


### PR DESCRIPTION
@SebastianStehle  I think you have missed this one. It didn't compile for me, so I guess this is the right change based on this: https://docs.microsoft.com/en-us/aspnet/core/migration/1x-to-2x/identity-2x
Tell me if im wrong. :smile: 