### PR TITLE
Allow Dropdown and Radio fields to be empty if they are not required

### DIFF
--- a/src/Squidex/app/features/content/pages/content/content-page.component.ts
+++ b/src/Squidex/app/features/content/pages/content/content-page.component.ts
@@ -253,7 +253,7 @@ export class ContentPageComponent implements CanComponentDeactivate, OnDestroy, 
                         fieldForm.controls[language.iso2Code].setValue(fieldValue[language.iso2Code]);
                     }
                 } else {
-                    fieldForm.controls['iv'].setValue(fieldValue['iv']);
+                    fieldForm.controls['iv'].setValue(fieldValue['iv'] === undefined ? null : fieldValue['iv']);
                 }
             }
 

--- a/src/Squidex/app/shared/services/schemas.service.ts
+++ b/src/Squidex/app/shared/services/schemas.service.ts
@@ -378,7 +378,11 @@ export class StringFieldPropertiesDto extends FieldPropertiesDto {
         }
 
         if (this.allowedValues && this.allowedValues.length > 0) {
-            validators.push(ValidatorsEx.validValues(this.allowedValues));
+            if (this.isRequired && !isOptional) {
+                validators.push(ValidatorsEx.validValues(this.allowedValues));
+            } else {
+                validators.push(ValidatorsEx.validValues(this.allowedValues.concat([null])));
+            }
         }
 
         return validators;


### PR DESCRIPTION
Currently, dropdown and radio fields are invalid until a value is selected even if they are not required and doesn't allow the user to save the content item. This update allows dropdown and radio fields to be submitted without selecting a value if the field is not required.