### PR TITLE
Number/Radio with Default Value always invalid

### DIFF
--- a/src/Squidex/app/shared/services/schemas.service.ts
+++ b/src/Squidex/app/shared/services/schemas.service.ts
@@ -426,7 +426,7 @@ export class NumberFieldPropertiesDto extends FieldPropertiesDto {
         }
 
         if (this.allowedValues && this.allowedValues.length > 0) {
-            validators.push(ValidatorsEx.validValues(this.allowedValues));
+            validators.push(ValidatorsEx.validValues(this.allowedValues.map(String)));
         }
 
         return validators;


### PR DESCRIPTION
When using a number field formatted as a Radio, and set a default value, the field is always invalid due to type mismatch between string and number.