### PR TITLE
Number/Radio with Default Value always invalid

### DIFF
--- a/src/Squidex/app/features/content/pages/content/content-field.component.html
+++ b/src/Squidex/app/features/content/pages/content/content-field.component.html
@@ -38,7 +38,7 @@
                             <div *ngSwitchCase="'Radio'">
                                 <div class="form-check form-check-inline" *ngFor="let value of field.properties.allowedValues">
                                     <label class="form-check-label">
-                                        <input class="form-check-input" type="radio" value="{{value}}" [formControlName]="partition"> {{value}}
+                                        <input class="form-check-input" type="radio" [value]="value" [formControlName]="partition"> {{value}}
                                     </label>
                                 </div>
                             </div>

--- a/src/Squidex/app/shared/services/schemas.service.ts
+++ b/src/Squidex/app/shared/services/schemas.service.ts
@@ -426,7 +426,7 @@ export class NumberFieldPropertiesDto extends FieldPropertiesDto {
         }
 
         if (this.allowedValues && this.allowedValues.length > 0) {
-            validators.push(ValidatorsEx.validValues(this.allowedValues.map(String)));
+            validators.push(ValidatorsEx.validValues(this.allowedValues));
         }
 
         return validators;


### PR DESCRIPTION
The PR from yesterday broke other types. Instead of casting to allowed values to string, should have forced the actual value to be correct type. My apologies for not testing other types first :(