### PR TITLE
Fix for migration in case of GetEventStore

### DIFF
--- a/src/Squidex.Infrastructure.GetEventStore/EventSourcing/GetEventStore.cs
+++ b/src/Squidex.Infrastructure.GetEventStore/EventSourcing/GetEventStore.cs
@@ -63,7 +63,7 @@ namespace Squidex.Infrastructure.EventSourcing
             StreamEventsSlice currentSlice;
             do
             {
-                currentSlice = await connection.ReadStreamEventsForwardAsync(GetStreamName(streamName), sliceStart, ReadPageSize, false);
+                currentSlice = await connection.ReadStreamEventsForwardAsync(streamName, sliceStart, ReadPageSize, true);
 
                 if (currentSlice.Status == SliceReadStatus.Success)
                 {


### PR DESCRIPTION
With GetEventStore the migration doesn't work, for two reasons:
- the calculated stream name is wrong
- the stream needs to be resolved

I'm not sure why this happened. I've seen new projections popping up in my ES instance, so I don't know how this was originally, but I managed to make it work with this change.
  