### PR TITLE
Fix SecurityDefinitions in Swagger helper

### DIFF
--- a/src/Squidex/Pipeline/Swagger/SwaggerHelper.cs
+++ b/src/Squidex/Pipeline/Swagger/SwaggerHelper.cs
@@ -72,7 +72,7 @@ namespace Squidex.Pipeline.Swagger
                 document.Host = context.Request.Host.Value;
             }
 
-            document.SecurityDefinitions.Add("OAuth2", CreateOAuthSchema(urlOptions));
+            document.SecurityDefinitions.Add(Constants.SecurityDefinition, CreateOAuthSchema(urlOptions));
 
             return document;
         }


### PR DESCRIPTION
According to OAS2 the key name in "security" should match with
the key name in "SecurityDefinitions" to apply intended security
to the specified scope.