### PR TITLE
Added strict port definition in program

### DIFF
--- a/src/Squidex/Program.cs
+++ b/src/Squidex/Program.cs
@@ -28,6 +28,7 @@ namespace Squidex
                 {
                     builder.AddAppConfiguration(hostContext.HostingEnvironment.EnvironmentName, args);
                 })
+                .UseUrls("http://localhost:5000/")
                 .Build()
                 .Run();
         }


### PR DESCRIPTION
On startup the program selects a dynamic port to run from by default, I've added a strict port definition to the program.cs file to solve this.