### PR TITLE
Cancel Edit Field does not close edit dropdown

### DIFF
--- a/src/Squidex/app/features/schemas/pages/schema/field.component.ts
+++ b/src/Squidex/app/features/schemas/pages/schema/field.component.ts
@@ -70,6 +70,7 @@ export class FieldComponent implements OnInit {
     }
 
     public cancel() {
+        this.isEditing = false;
         this.editForm.load(this.field);
     }
 


### PR DESCRIPTION
Cancel Edit Field only clears the fields, missing isEditing = false to force it to close.