### PR TITLE
Alpine linux docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,21 +28,25 @@ RUN dotnet restore \
  && dotnet test tests/Squidex.Tests/Squidex.Tests.csproj
 
 # Publish
-RUN dotnet publish src/Squidex/Squidex.csproj --output /out/ --configuration Release
+RUN dotnet publish src/Squidex/Squidex.csproj --output /out/alpine --configuration Release -r alpine.3.7-x64
 
 #
 # Stage 2, Build runtime
 #
-FROM microsoft/dotnet:2.1.0-aspnetcore-runtime
+FROM microsoft/dotnet:2.1-runtime-deps-alpine
 
 # Default AspNetCore directory
 WORKDIR /app
 
+# add libuv
+RUN apk add --no-cache libuv \
+&& ln -s /usr/lib/libuv.so.1 /usr/lib/libuv.so
+
 # Copy from build stage
-COPY --from=builder /out/ .
+COPY --from=builder /out/alpine .
 
 EXPOSE 80
 EXPOSE 33333
 EXPOSE 40000
 
-ENTRYPOINT ["dotnet", "Squidex.dll"]
+ENTRYPOINT ["./Squidex"]

--- a/src/Squidex/Squidex.csproj
+++ b/src/Squidex/Squidex.csproj
@@ -6,6 +6,7 @@
     <PackageId>Squidex</PackageId>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.1</RuntimeFrameworkVersion>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
   </PropertyGroup>

--- a/tests/Squidex.Tests/Squidex.Tests.csproj
+++ b/tests/Squidex.Tests/Squidex.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.1</RuntimeFrameworkVersion>
     <RootNamespace>Squidex</RootNamespace>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
I've changed the dockerfile to build an alpine image, and also I've changed the .csproj file of the Squidex project to be bound to the 2.1.1 dotnet runtime. This way the image size will be around 163MB, which could be reduced to around 90MB but I didn't want to risk it.
@SebastianStehle what are the tests you used to conduct to verify it is stable with such changes?