### PR TITLE
No error message for Schedule Error

### DIFF
--- a/src/Squidex/app/shared/state/contents.state.ts
+++ b/src/Squidex/app/shared/state/contents.state.ts
@@ -12,6 +12,7 @@ import { catchError, distinctUntilChanged, map, switchMap, tap } from 'rxjs/oper
 import {
     DateTime,
     DialogService,
+    ErrorDto,
     ImmutableArray,
     notify,
     Pager,
@@ -152,7 +153,7 @@ export abstract class ContentsStateBase extends State<Snapshot> {
                 this.contentsService.changeContentStatus(this.appName, this.schemaName, c.id, action, dueTime, c.version).pipe(
                     catchError(error => of(error))))).pipe(
             tap(results => {
-                const error = results.find(x => !!x.error);
+                const error = results.find(x => x instanceof ErrorDto);
 
                 if (error) {
                     this.dialogs.notifyError(error);
@@ -169,7 +170,7 @@ export abstract class ContentsStateBase extends State<Snapshot> {
                 this.contentsService.deleteContent(this.appName, this.schemaName, c.id, c.version).pipe(
                     catchError(error => of(error))))).pipe(
             tap(results => {
-                const error = results.find(x => !!x.error);
+                const error = results.find(x => x instanceof ErrorDto);
 
                 if (error) {
                     this.dialogs.notifyError(error);


### PR DESCRIPTION
When saving invalid schedule, error is returned from API, but not displayed. Simple way to recreate is schedule item and enter invalid year (I.E. 0000). 

I think this may be proper fix, other solution is to remove the catcherror and extra pipe.