### PR TITLE
Pending should be false when changing status

### DIFF
--- a/src/Squidex.Domain.Apps.Entities/Contents/State/ContentState.cs
+++ b/src/Squidex.Domain.Apps.Entities/Contents/State/ContentState.cs
@@ -86,6 +86,7 @@ namespace Squidex.Domain.Apps.Entities.Contents.State
         protected void On(ContentStatusChanged @event)
         {
             ScheduleJob = null;
+            IsPending = false;
 
             Status = @event.Status;
 


### PR DESCRIPTION
Fixing a weird state on content
1. Create and publish a content item
2. Make a pending change
3. Select "Unpublish" and the pending data is still there.

If you're unpublished, you shouldn't be able to have a pending version.