### PR TITLE
Additional character for client part separation.

### DIFF
--- a/src/Squidex/Pipeline/Extensions.cs
+++ b/src/Squidex/Pipeline/Extensions.cs
@@ -22,7 +22,7 @@ namespace Squidex.Pipeline
         {
             var clientId = principal.FindFirst(OpenIdClaims.ClientId)?.Value;
 
-            var clientIdParts = clientId?.Split(':');
+            var clientIdParts = clientId?.Split(':', '~');
 
             if (clientIdParts?.Length != 2)
             {


### PR DESCRIPTION
https://support.squidex.io/t/fallback-character-for-app-name-client-id-seperation/304