### PR TITLE
fixed duplicate permission

### DIFF
--- a/src/Squidex.Domain.Apps.Entities/Apps/RoleExtensions.cs
+++ b/src/Squidex.Domain.Apps.Entities/Apps/RoleExtensions.cs
@@ -30,7 +30,7 @@ namespace Squidex.Domain.Apps.Entities.Apps
                 }
             }
 
-            permissions = result;
+            permissions = result.Distinct().ToArray();
 
             return permissions;
         }

--- a/tests/Squidex.Domain.Apps.Entities.Tests/Apps/RoleExtensionsRests.cs
+++ b/tests/Squidex.Domain.Apps.Entities.Tests/Apps/RoleExtensionsRests.cs
@@ -24,6 +24,14 @@ namespace Squidex.Domain.Apps.Entities.Apps
         }
 
         [Fact]
+        public void Should_not_have_duplicate_permission()
+        {
+            var source = new[] { "common", "common", "common" };
+            var result = source.Prefix("my-app");
+            Assert.Single(result);
+        }
+
+        [Fact]
         public void Should_prefix_permission()
         {
             var source = new[] { "clients.read" };


### PR DESCRIPTION
Duplicate 'common' occurs when the user saves the role.
![dp](https://user-images.githubusercontent.com/7090368/50371975-6f627180-0600-11e9-8da1-4f5d8ccd133f.gif)
