### PR TITLE
renaming disabled to isDisabled

### DIFF
--- a/src/Squidex/app/framework/angular/forms/iframe-editor.component.ts
+++ b/src/Squidex/app/framework/angular/forms/iframe-editor.component.ts
@@ -65,7 +65,7 @@ export class IFrameEditorComponent implements ControlValueAccessor, AfterViewIni
                         this.isInitialized = true;
 
                         if (this.plugin.contentWindow && Types.isFunction(this.plugin.contentWindow.postMessage)) {
-                            this.plugin.contentWindow.postMessage({ type: 'disabled', disabled: this.isDisabled }, '*');
+                            this.plugin.contentWindow.postMessage({ type: 'disabled', isDisabled: this.isDisabled }, '*');
                             this.plugin.contentWindow.postMessage({ type: 'valueChanged', value: this.value }, '*');
                         }
                     } else if (type === 'resize') {
@@ -99,7 +99,7 @@ export class IFrameEditorComponent implements ControlValueAccessor, AfterViewIni
         this.isDisabled = isDisabled;
 
         if (this.isInitialized && this.plugin.contentWindow && Types.isFunction(this.plugin.contentWindow.postMessage)) {
-            this.plugin.contentWindow.postMessage({ type: 'disabled', disabled: this.isDisabled }, '*');
+            this.plugin.contentWindow.postMessage({ type: 'disabled', isDisabled: this.isDisabled }, '*');
         }
     }
 


### PR DESCRIPTION
Editor-sdk.js is using isDisabled. but iframe-editor is using disable. 

![iframeediter](https://user-images.githubusercontent.com/7090368/50382092-43afbc00-06d2-11e9-983a-22ff23d14a56.gif)
