### PR TITLE
Fixed issue with unpublished content not being available for GraphQL

### DIFF
--- a/src/Squidex.Domain.Apps.Entities/Contents/GraphQL/Types/ContentGraphType.cs
+++ b/src/Squidex.Domain.Apps.Entities/Contents/GraphQL/Types/ContentGraphType.cs
@@ -99,7 +99,7 @@ namespace Squidex.Domain.Apps.Entities.Contents.GraphQL.Types
                 AddField(new FieldType
                 {
                     Name = "dataDraft",
-                    ResolvedType = new NonNullGraphType(contentDataType),
+                    ResolvedType = contentDataType,
                     Resolver = Resolve(x => x.DataDraft),
                     Description = $"The draft data of the {schemaName} content."
                 });

--- a/src/Squidex.Domain.Apps.Entities/Contents/GraphQL/Types/ContentGraphType.cs
+++ b/src/Squidex.Domain.Apps.Entities/Contents/GraphQL/Types/ContentGraphType.cs
@@ -95,6 +95,14 @@ namespace Squidex.Domain.Apps.Entities.Contents.GraphQL.Types
                     Resolver = Resolve(x => x.Data),
                     Description = $"The data of the {schemaName} content."
                 });
+
+                AddField(new FieldType
+                {
+                    Name = "dataDraft",
+                    ResolvedType = new NonNullGraphType(contentDataType),
+                    Resolver = Resolve(x => x.DataDraft),
+                    Description = $"The draft data of the {schemaName} content."
+                });
             }
 
             Description = $"The structure of a {schemaName} content type.";

--- a/tests/Squidex.Domain.Apps.Entities.Tests/Contents/GraphQL/GraphQLTestBase.cs
+++ b/tests/Squidex.Domain.Apps.Entities.Tests/Contents/GraphQL/GraphQLTestBase.cs
@@ -97,7 +97,7 @@ namespace Squidex.Domain.Apps.Entities.Contents.GraphQL
             sut = new CachingGraphQLService(cache, appProvider, assetQuery, contentQuery, new FakeUrlGenerator());
         }
 
-        protected static IContentEntity CreateContent(Guid id, Guid refId, Guid assetId, NamedContentData data = null)
+        protected static IContentEntity CreateContent(Guid id, Guid refId, Guid assetId, NamedContentData data = null, NamedContentData dataDraft = null)
         {
             var now = SystemClock.Instance.GetCurrentInstant();
 
@@ -151,7 +151,8 @@ namespace Squidex.Domain.Apps.Entities.Contents.GraphQL
                 CreatedBy = new RefToken(RefTokenType.Subject, "user1"),
                 LastModified = now,
                 LastModifiedBy = new RefToken(RefTokenType.Subject, "user2"),
-                Data = data
+                Data = data,
+                DataDraft = dataDraft
             };
 
             return content;


### PR DESCRIPTION
Fixed issue with unpublished content not being available for GraphQL queries. See https://support.squidex.io/t/unpublished-content-through-graphql/457 for more details.