### PR TITLE
Make orleans ports configurable

### DIFF
--- a/src/Squidex/Config/Orleans/OrleansServices.cs
+++ b/src/Squidex/Config/Orleans/OrleansServices.cs
@@ -58,8 +58,8 @@ namespace Squidex.Config.Orleans
             {
                 ["MongoDB"] = () =>
                 {
-                    var siloPort = int.Parse(Environment.GetEnvironmentVariable("Orleans.SiloPort") ?? "11111");
-                    var gatewayPort = int.Parse(Environment.GetEnvironmentVariable("Orleans.GatewayPort") ?? "40000");
+                    int siloPort = int.TryParse(config.GetRequiredValue("orleans:siloPort"), out siloPort) ? siloPort : 11111;
+                    int gatewayPort = int.TryParse(config.GetRequiredValue("orleans:gatewayPort"), out gatewayPort) ? gatewayPort : 40000;
 
                     hostBuilder.ConfigureEndpoints(Dns.GetHostName(), siloPort, gatewayPort, listenOnAnyHostAddress: true);
 

--- a/src/Squidex/Config/Orleans/OrleansServices.cs
+++ b/src/Squidex/Config/Orleans/OrleansServices.cs
@@ -58,8 +58,8 @@ namespace Squidex.Config.Orleans
             {
                 ["MongoDB"] = () =>
                 {
-                    var siloPort = int.Parse(config.GetRequiredValue("orleans:siloPort") ?? "11111");
-                    var gatewayPort = int.Parse(config.GetRequiredValue("orleans:gatewayPort") ?? "400000");
+                    var siloPort = int.Parse(Environment.GetEnvironmentVariable("Orleans.SiloPort") ?? "11111");
+                    var gatewayPort = int.Parse(Environment.GetEnvironmentVariable("Orleans.GatewayPort") ?? "40000");
 
                     hostBuilder.ConfigureEndpoints(Dns.GetHostName(), siloPort, gatewayPort, listenOnAnyHostAddress: true);
 

--- a/src/Squidex/Config/Orleans/OrleansServices.cs
+++ b/src/Squidex/Config/Orleans/OrleansServices.cs
@@ -58,7 +58,10 @@ namespace Squidex.Config.Orleans
             {
                 ["MongoDB"] = () =>
                 {
-                    hostBuilder.ConfigureEndpoints(Dns.GetHostName(), 11111, 40000, listenOnAnyHostAddress: true);
+                    var siloPort = int.Parse(config.GetRequiredValue("orleans:siloPort") ?? "11111");
+                    var gatewayPort = int.Parse(config.GetRequiredValue("orleans:gatewayPort") ?? "400000");
+
+                    hostBuilder.ConfigureEndpoints(Dns.GetHostName(), siloPort, gatewayPort, listenOnAnyHostAddress: true);
 
                     var mongoConfiguration = config.GetRequiredValue("store:mongoDb:configuration");
                     var mongoDatabaseName = config.GetRequiredValue("store:mongoDb:database");

--- a/src/Squidex/appsettings.json
+++ b/src/Squidex/appsettings.json
@@ -177,7 +177,9 @@
      * 
      * Supported: MongoDB, Development
      */
-    "clustering": "MongoDb"
+    "clustering": "MongoDb",
+    "siloPort": 11112,
+    "gatewayPort":  40002 
   },
 
   "eventStore": {

--- a/src/Squidex/appsettings.json
+++ b/src/Squidex/appsettings.json
@@ -177,9 +177,7 @@
      * 
      * Supported: MongoDB, Development
      */
-    "clustering": "MongoDb",
-    "siloPort": 11112,
-    "gatewayPort":  40002 
+    "clustering": "MongoDb"
   },
 
   "eventStore": {

--- a/src/Squidex/appsettings.json
+++ b/src/Squidex/appsettings.json
@@ -177,7 +177,13 @@
      * 
      * Supported: MongoDB, Development
      */
-    "clustering": "MongoDb"
+    "clustering": "MongoDb",
+    /*
+     * The ports used to host the Orleans silo and the Gateway to connect to it
+     * optional: defaults to 11111 (silo) and 40000 (gateway) when not provided
+     */
+    "siloPort": "11111",
+    "gatewayPort": "40000"
   },
 
   "eventStore": {


### PR DESCRIPTION
We're hosting Squidex on Microsoft Azure Webapps. For deployment we're using a blue-green deployment model with different slots within an Azure webapp (http://www.tiernok.com/posts/blue-green-deployment-to-azure-app-services/).

This works like a charm. Only with Orleans this might lead to a situation where both slots are on the same backend server trying to setup a Silo with the same ports. 

Attached change will use an EnvironmentVariable to override the default siloPort and gatewayPort. 

This way we can give the Orleans cluster different port numbers per slot. 