### PR TITLE
Update field-wizard.component.html

### DIFF
--- a/src/Squidex/app/features/schemas/pages/schema/field-wizard.component.html
+++ b/src/Squidex/app/features/schemas/pages/schema/field-wizard.component.html
@@ -18,7 +18,7 @@
                     <div class="row">
                         <div class="col-4 type" *ngFor="let fieldType of fieldTypes">
                             <label>
-                                <input type="radio" class="radio-input" formControlName="type" value="{{fieldType.type}}" name="fieldType" />
+                                <input type="radio" class="radio-input" formControlName="type" value="{{fieldType.type}}" name="type" />
 
                                 <div class="row no-gutters">
                                     <div class="col-auto">


### PR DESCRIPTION
fix bug, details here: https://support.squidex.io/t/bug-when-creating-new-schema-field-if-you-define-both-a-name-and-a-formcontrolname-attribute-on-your-radio-button-their-values-must-match/671