### PR TITLE
Maximum callstacksize exceeded

### DIFF
--- a/src/Squidex/app/framework/angular/forms/control-errors.component.ts
+++ b/src/Squidex/app/framework/angular/forms/control-errors.component.ts
@@ -60,7 +60,7 @@ export class ControlErrorsComponent extends StatefulComponent<State> implements 
 
     public ngOnDestroy() {
         super.ngOnDestroy();
-		this.restoreOriginalMarkAsTouchedFunction();
+	this.restoreOriginalMarkAsTouchedFunction();
     }
 
     public ngOnChanges() {
@@ -84,7 +84,7 @@ export class ControlErrorsComponent extends StatefulComponent<State> implements 
 
         if (this.control !== control) {
             this.unsubscribeAll();
-			this.restoreOriginalMarkAsTouchedFunction();
+	    this.restoreOriginalMarkAsTouchedFunction();
 
             this.control = control;
 
@@ -110,11 +110,11 @@ export class ControlErrorsComponent extends StatefulComponent<State> implements 
         this.createMessages();
     }
 
-	private restoreOriginalMarkAsTouchedFunction() {
-		if (this.control && this.originalMarkAsTouched) {
-			this.control['markAsTouched'] = this.originalMarkAsTouched;
-		}
+    private restoreOriginalMarkAsTouchedFunction() {
+	if (this.control && this.originalMarkAsTouched) {
+		this.control['markAsTouched'] = this.originalMarkAsTouched;
 	}
+    }
 
     private createMessages() {
         const errors: string[] = [];

--- a/src/Squidex/app/framework/angular/forms/control-errors.component.ts
+++ b/src/Squidex/app/framework/angular/forms/control-errors.component.ts
@@ -60,10 +60,7 @@ export class ControlErrorsComponent extends StatefulComponent<State> implements 
 
     public ngOnDestroy() {
         super.ngOnDestroy();
-
-        if (this.control && this.originalMarkAsTouched) {
-            this.control['markAsTouched'] = this.originalMarkAsTouched;
-        }
+		this.restoreOriginalMarkAsTouchedFunction();
     }
 
     public ngOnChanges() {
@@ -87,6 +84,7 @@ export class ControlErrorsComponent extends StatefulComponent<State> implements 
 
         if (this.control !== control) {
             this.unsubscribeAll();
+			this.restoreOriginalMarkAsTouchedFunction();
 
             this.control = control;
 
@@ -111,6 +109,12 @@ export class ControlErrorsComponent extends StatefulComponent<State> implements 
 
         this.createMessages();
     }
+
+	private restoreOriginalMarkAsTouchedFunction() {
+		if (this.control && this.originalMarkAsTouched) {
+			this.control['markAsTouched'] = this.originalMarkAsTouched;
+		}
+	}
 
     private createMessages() {
         const errors: string[] = [];


### PR DESCRIPTION
Hi i discovered an issue with control-errors component and rich text editor.

It will throw error "maximum call stack size exceeded". Changes to the tinyMCE editor are lost upon saveing sometimes.

To reproduce this issue:

1. Have at least two languages active in your app
2. Create Schema with localizable field with rich text editor
3. Create new content for that schema.
4. Modify rich text for language 1
5. Switch language to language 2
6. Modify rich text for language 2
7. Switch language to language 1 again
8. Modify rich text for language 1
9. Click save Button
![reproduce error](https://user-images.githubusercontent.com/7125443/57178317-864a8780-6e6e-11e9-9e14-53323c31947e.gif)



I found out, that this issue seems to be caused by the control-errors component decorating the markAsTouched function of the formControls. But when the formcontrol changes on language switch, the original function is not restored.