### PR TITLE
Include specific tenant in Microsoft Authentication

### DIFF
--- a/backend/src/Squidex/Config/Authentication/MicrosoftAuthenticationServices.cs
+++ b/backend/src/Squidex/Config/Authentication/MicrosoftAuthenticationServices.cs
@@ -21,6 +21,15 @@ namespace Squidex.Config.Authentication
                     options.ClientId = identityOptions.MicrosoftClient;
                     options.ClientSecret = identityOptions.MicrosoftSecret;
                     options.Events = new MicrosoftHandler();
+
+                    var tenantId = identityOptions.MicrosoftTenant;
+
+                    if (!string.IsNullOrEmpty(tenantId))
+                    {
+                        var resource = "https://graph.microsoft.com";
+                        options.AuthorizationEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/authorize?resource={resource}";
+                        options.TokenEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/token?resource={resource}";
+                    }
                 });
             }
 

--- a/backend/src/Squidex/Config/MyIdentityOptions.cs
+++ b/backend/src/Squidex/Config/MyIdentityOptions.cs
@@ -35,6 +35,8 @@ namespace Squidex.Config
 
         public string MicrosoftSecret { get; set; }
 
+        public string MicrosoftTenant { get; set; }
+
         public string OidcName { get; set; }
 
         public string OidcClient { get; set; }

--- a/backend/src/Squidex/appsettings.json
+++ b/backend/src/Squidex/appsettings.json
@@ -479,9 +479,11 @@
     "githubSecret": "d0a0d0fe2c26469ae20987ac265b3a339fd73132",
     /*
      * Settings for Microsoft auth (keep empty to disable).
+     * Tennant is optional for using a specific AzureAD tenant
      */
     "microsoftClient": "b55da740-6648-4502-8746-b9003f29d5f1",
     "microsoftSecret": "idWbANxNYEF4cB368WXJhjN",
+    "microsoftTenant": null,
     /*
      * Settings for your custom oidc server.
      */


### PR DESCRIPTION
Microsoft Authentication uses a default endpoint for AzureAD authentication. This make authentication with any AzureAd account possible. 

When you wish to limit this to only users from your own AzureAD you need to specify a specific AzureAD tenant. 

This pull request implements adding an optional tenantId field. 

How to test:
- Create an Azure App registration in Azure Active directory.
- Configure Squidex to use this clientId and clientSecret
- Authenticate and verify access --> when no tenant is specified should work as default.

- Change the Azure App registration so only users from this directory can sign in. 
- Restart Squidex
- Try to sign in --> you should get an error stating that the common endpoint cannot be used to authenticate users for a specific AzureAD. 

- Add your AzureAD tenantId to the settings of squidex
- Restart Squidex
- Authenticate --> this should now work as expected