### PR TITLE
Feature/force path style amazon client config

### DIFF
--- a/backend/src/Squidex.Infrastructure.Amazon/Assets/AmazonS3AssetStore.cs
+++ b/backend/src/Squidex.Infrastructure.Amazon/Assets/AmazonS3AssetStore.cs
@@ -24,11 +24,12 @@ namespace Squidex.Infrastructure.Assets
         private readonly string secretKey;
         private readonly string bucketName;
         private readonly string? bucketFolder;
+        private readonly bool forcePathStyle;
         private readonly RegionEndpoint bucketRegion;
         private TransferUtility transferUtility;
         private IAmazonS3 s3Client;
 
-        public AmazonS3AssetStore(string? serviceUrl, string? regionName, string bucketName, string? bucketFolder, string accessKey, string secretKey)
+        public AmazonS3AssetStore(string? serviceUrl, string? regionName, string bucketName, string? bucketFolder, string accessKey, string secretKey, bool forcePathStyle)
         {
             Guard.NotNullOrEmpty(bucketName);
             Guard.NotNullOrEmpty(accessKey);
@@ -39,6 +40,7 @@ namespace Squidex.Infrastructure.Assets
             this.bucketFolder = bucketFolder;
             this.accessKey = accessKey;
             this.secretKey = secretKey;
+            this.forcePathStyle = forcePathStyle;
 
             bucketRegion = RegionEndpoint.GetBySystemName(regionName);
         }
@@ -62,7 +64,7 @@ namespace Squidex.Infrastructure.Assets
                     s3Client = new AmazonS3Client(
                         accessKey,
                         secretKey,
-                        new AmazonS3Config { ServiceURL = serviceUrl });
+                        new AmazonS3Config { ServiceURL = serviceUrl, ForcePathStyle = forcePathStyle });
                 }
                 else
                 {

--- a/backend/src/Squidex.Infrastructure.Amazon/MyAmazonS3Options.cs
+++ b/backend/src/Squidex.Infrastructure.Amazon/MyAmazonS3Options.cs
@@ -1,0 +1,26 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschränkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.Infrastructure
+{
+    public class MyAmazonS3Options
+    {
+        public string? ServiceUrl { get; set; }
+
+        public string? RegionName { get; set; }
+
+        public string Bucket { get; set; }
+
+        public string? BucketFolder { get; set; }
+
+        public string AccessKey { get; set; }
+
+        public string SecretKey { get; set; }
+
+        public bool ForcePathStyle { get; set; }
+    }
+}

--- a/backend/src/Squidex/Config/Domain/AssetServices.cs
+++ b/backend/src/Squidex/Config/Domain/AssetServices.cs
@@ -88,18 +88,9 @@ namespace Squidex.Config.Domain
                 },
                 ["AmazonS3"] = () =>
                 {
-                    var serviceUrl = config.GetOptionalValue<string>("assetStore:amazonS3:serviceUrl");
-                    var regionName = config.GetOptionalValue<string>("assetStore:amazonS3:regionName");
+                    var amazonS3Options = config.GetOptionalValue<MyAmazonS3Options>("assetStore:amazonS3");
 
-                    var bucketName = config.GetRequiredValue("assetStore:amazonS3:bucket");
-                    var bucketFolder = config.GetRequiredValue("assetStore:amazonS3:bucketFolder");
-
-                    var accessKey = config.GetRequiredValue("assetStore:amazonS3:accessKey");
-                    var secretKey = config.GetRequiredValue("assetStore:amazonS3:secretKey");
-
-                    var forcePathStyle = config.GetOptionalValue<bool>("assetStore:amazonS3:forcePathStyle", false);
-
-                    services.AddSingletonAs(c => new AmazonS3AssetStore(serviceUrl, regionName, bucketName, bucketFolder, accessKey, secretKey, forcePathStyle))
+                    services.AddSingletonAs(c => new AmazonS3AssetStore(amazonS3Options))
                         .As<IAssetStore>();
                 },
                 ["MongoDb"] = () =>

--- a/backend/src/Squidex/Config/Domain/AssetServices.cs
+++ b/backend/src/Squidex/Config/Domain/AssetServices.cs
@@ -97,7 +97,9 @@ namespace Squidex.Config.Domain
                     var accessKey = config.GetRequiredValue("assetStore:amazonS3:accessKey");
                     var secretKey = config.GetRequiredValue("assetStore:amazonS3:secretKey");
 
-                    services.AddSingletonAs(c => new AmazonS3AssetStore(serviceUrl, regionName, bucketName, bucketFolder, accessKey, secretKey))
+                    var forcePathStyle = config.GetOptionalValue<bool>("assetStore:amazonS3:forcePathStyle", false);
+
+                    services.AddSingletonAs(c => new AmazonS3AssetStore(serviceUrl, regionName, bucketName, bucketFolder, accessKey, secretKey, forcePathStyle))
                         .As<IAssetStore>();
                 },
                 ["MongoDb"] = () =>

--- a/backend/src/Squidex/appsettings.json
+++ b/backend/src/Squidex/appsettings.json
@@ -288,7 +288,7 @@
       /*
        * The url of the S3 API service. Leave it empty if using the one provided by Amazon
        */
-      "serviceUrl": "", 
+      "serviceUrl": "",
 
       /*
        * The name of your bucket.
@@ -317,7 +317,12 @@
        *
        * Read More: https://supsystic.com/documentation/id-secret-access-key-amazon-s3/
        */
-      "secretKey": "<MY_SECRET>"
+      "secretKey": "<MY_SECRET>",
+
+      /*
+       * Force path style property for AmazonS3Config
+       */
+      "forcePathStyle":  false 
     },
     "mongoDb": {
       /*

--- a/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreFixture.cs
+++ b/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreFixture.cs
@@ -13,7 +13,7 @@ namespace Squidex.Infrastructure.Assets
 
         public AmazonS3AssetStoreFixture()
         {
-            AssetStore = new AmazonS3AssetStore(null, "eu-central-1", "squidex-test", "squidex-assets", "secret", "secret");
+            AssetStore = new AmazonS3AssetStore(null, "eu-central-1", "squidex-test", "squidex-assets", "secret", "secret", false);
             AssetStore.InitializeAsync().Wait();
         }
     }

--- a/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreFixture.cs
+++ b/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreFixture.cs
@@ -13,7 +13,16 @@ namespace Squidex.Infrastructure.Assets
 
         public AmazonS3AssetStoreFixture()
         {
-            AssetStore = new AmazonS3AssetStore(null, "eu-central-1", "squidex-test", "squidex-assets", "secret", "secret", false);
+            AssetStore = new AmazonS3AssetStore(new MyAmazonS3Options
+            {
+                ServiceUrl = null,
+                RegionName = "eu-central-1",
+                Bucket = "squidex-test",
+                BucketFolder = "squidex-assets",
+                AccessKey = "secret",
+                SecretKey = "secret",
+                ForcePathStyle = false
+            });
             AssetStore.InitializeAsync().Wait();
         }
     }

--- a/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreTests.cs
+++ b/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreTests.cs
@@ -28,7 +28,16 @@ namespace Squidex.Infrastructure.Assets
         [Fact]
         public async Task Should_throw_exception_for_invalid_config()
         {
-            var sut = new AmazonS3AssetStore(null, "invalid", "invalid", null, "invalid", "invalid", false);
+            var sut = new AmazonS3AssetStore(new MyAmazonS3Options
+            {
+                ServiceUrl = null,
+                RegionName = "invalid",
+                Bucket = "invalid",
+                BucketFolder = null,
+                AccessKey = "invalid",
+                SecretKey = "invalid",
+                ForcePathStyle = false
+            });
 
             await Assert.ThrowsAsync<ConfigurationException>(() => sut.InitializeAsync());
         }

--- a/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreTests.cs
+++ b/backend/tests/Squidex.Infrastructure.Tests/Assets/AmazonS3AssetStoreTests.cs
@@ -28,7 +28,7 @@ namespace Squidex.Infrastructure.Assets
         [Fact]
         public async Task Should_throw_exception_for_invalid_config()
         {
-            var sut = new AmazonS3AssetStore(null, "invalid", "invalid", null, "invalid", "invalid");
+            var sut = new AmazonS3AssetStore(null, "invalid", "invalid", null, "invalid", "invalid", false);
 
             await Assert.ThrowsAsync<ConfigurationException>(() => sut.InitializeAsync());
         }


### PR DESCRIPTION
Right now AmazonS3 config used with its default property values. Some S3 API implementation requires specific configuration. I added only `ForcePathStyle` config, but in future would be good to allow set all configurations for AmazonS3 Client.