### PR TITLE
Increase severity of locked field warning

### DIFF
--- a/frontend/app/features/schemas/pages/schema/field.component.html
+++ b/frontend/app/features/schemas/pages/schema/field.component.html
@@ -54,7 +54,7 @@
                                     <a class="dropdown-item" 
                                         (sqxConfirmClick)="lockField()"
                                         confirmTitle="Lock field" 
-                                        confirmText="Do you really want to lock the field? Locked fields cannot be deleted or changed anymore.">
+                                        confirmText="WARNING: Locking a field cannot be undone! Locked field definitions cannot be unlocked, deleted, or changed anymore. Do you really want to lock this field?">
                                         Lock and prevent changes
                                     </a>
                                 </ng-container>


### PR DESCRIPTION
Spawned by [this conversation](https://support.squidex.io/t/is-it-possible-to-unlock-a-field-that-was-accidentally-locked/1558), I'd like to increase the warning text associated with locking a field, because it cannot be undone and one's only recourse is to rebuild the entity and its contents.