### PR TITLE
Added support for manually specifying IP Address for the Orleans silo

### DIFF
--- a/frontend/app/theme/_bootstrap-vars.scss
+++ b/frontend/app/theme/_bootstrap-vars.scss
@@ -45,7 +45,7 @@ $modal-backdrop-opacity:    .35;
 $modal-footer-border-width: 1px;
 $modal-header-border-width: 0;
 $modal-header-padding:      1rem 1.75rem;
-$modal-inner-padding:       1.5rem 1.75rem;
+$modal-inner-padding:       1.75rem;
 $modal-md:                  560px;
 $modal-title-line-height:   1.8rem;
 

--- a/frontend/app/theme/_bootstrap.scss
+++ b/frontend/app/theme/_bootstrap.scss
@@ -708,7 +708,8 @@ $icon-size: 4.5rem;
     }
 
     &-footer {
-        padding: .75rem 1.25rem;
+        padding-bottom: 1.25rem;
+        padding-top: 1.25rem;
 
         .clearfix {
             width: 100%;


### PR DESCRIPTION
This adds support for manually specifying the IP address for a Squidex application's Orleans silo, through the `orleans:ipAddress` configuration setting.

This is needed in certain scenarios where the Squidex application is hosted inside of Docker containers, and the IP used for the silo should **not** be the container's IP address (i.e. *172.17.x.x*).

This issue was discussed in the following discussion in the official Squidex Support forum:

* https://support.squidex.io/t/load-balancer-out-of-sync-when-new-schemas-are-created/1646

And the code change itself was suggested by @SebastianStehle in this commit:

* https://github.com/Squidex/squidex/commit/8287340a84c99c18cef98af42bae128c56eeec6d