### PR TITLE
add IsSingleton in SynchronizeSchemaDto

### DIFF
--- a/backend/src/Squidex/Areas/Api/Controllers/Schemas/Models/SynchronizeSchemaDto.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Schemas/Models/SynchronizeSchemaDto.cs
@@ -21,6 +21,11 @@ namespace Squidex.Areas.Api.Controllers.Schemas.Models
         /// </summary>
         public bool NoFieldRecreation { get; set; }
 
+        /// <summary>
+        /// True, when schema allows only one item.
+        /// </summary>
+        public bool IsSingleton { get; set; }
+
         public SynchronizeSchema ToCommand()
         {
             return ToCommand(this, new SynchronizeSchema());


### PR DESCRIPTION
Added IsSingleton field in SynchronizeSchemaDto so it can be used by Squidex CLI during schema export/import in [SchemasSynchronizer.cs](https://github.com/Squidex/squidex-samples/blob/master/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemasSynchronizer.cs).

Currently Squidex CLI has an issue with exprot/import of singleton schemas. Schema is always multiple in case you create it from CLI.

Steps to reproduce issue:
1. Create new test `Single content` schema in Squidex CMS.
2. Run export `dotnet sq sync out`.
3. Delete test Single content schema from Squidex CMS.
4. Run import `dotnet sq sync in`
5. Now test schema became of `Multiple contents` type, but it must remain `Single content`

Happy to create another PR for Squidex CLI whenever updated SynchronizeSchemaDto is available 🙂 
