### PR TITLE
bug: fix identity server profile page showing client secret label as Client ID

### DIFF
--- a/backend/src/Squidex/Areas/IdentityServer/Views/Profile/Profile.cshtml
+++ b/backend/src/Squidex/Areas/IdentityServer/Views/Profile/Profile.cshtml
@@ -198,14 +198,14 @@
 
     <div class="row no-gutters form-group">
         <div class="col-8">
-            <label for="clientId">Client Id</label>
+            <label for="clientId">@T.Get("common.clientId")</label>
 
             <input class="form-control" name="clientId" id="clientId" readonly value="@Model.Id" />
         </div>
     </div>
     <div class="row no-gutters form-group">
         <div class="col-8">
-            <label for="clientSecret">@T.Get("common.clientId")</label>
+            <label for="clientSecret">@T.Get("common.clientSecret")</label>
 
             <input class="form-control" name="clientSecret" id="clientSecret" readonly value="@Model.ClientSecret" />
         </div>


### PR DESCRIPTION
Fix this:

![image](https://user-images.githubusercontent.com/6273429/101250084-5f70c900-3715-11eb-96c9-094338194f89.png)
