### PR TITLE
Feat/enhanced oidc settings

### DIFF
--- a/backend/src/Squidex.Infrastructure/Security/Extensions.cs
+++ b/backend/src/Squidex.Infrastructure/Security/Extensions.cs
@@ -67,6 +67,12 @@ namespace Squidex.Infrastructure.Security
             return principal.Claims.FirstOrDefault(x => x.Type == OpenIdClaims.Email)?.Value;
         }
 
+        public static string? TryFindEmail(this ClaimsPrincipal principal)
+        {
+            return principal.Claims.FirstOrDefault(x => x.Type == ClaimTypes.Email)?.Value ??
+                   principal.Claims.FirstOrDefault(x => x.Type == OpenIdClaims.Email)?.Value;
+        }
+
         public static bool IsInClient(this ClaimsPrincipal principal, string client)
         {
             return principal.Claims.Any(x => x.Type == OpenIdClaims.ClientId && string.Equals(x.Value, client, StringComparison.OrdinalIgnoreCase));

--- a/backend/src/Squidex/Areas/IdentityServer/Controllers/Account/AccountController.cs
+++ b/backend/src/Squidex/Areas/IdentityServer/Controllers/Account/AccountController.cs
@@ -294,7 +294,7 @@ namespace Squidex.Areas.IdentityServer.Controllers.Account
             }
             else
             {
-                var email = externalLogin.Principal.FindFirst(ClaimTypes.Email)?.Value!;
+                var email = externalLogin.Principal.TryFindEmail();
 
                 user = await userManager.FindByEmailWithClaimsAsync(email);
 

--- a/backend/src/Squidex/Areas/IdentityServer/Controllers/Extensions.cs
+++ b/backend/src/Squidex/Areas/IdentityServer/Controllers/Extensions.cs
@@ -12,6 +12,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Identity;
+using Squidex.Infrastructure.Security;
 using Squidex.Web;
 
 namespace Squidex.Areas.IdentityServer.Controllers
@@ -22,7 +23,7 @@ namespace Squidex.Areas.IdentityServer.Controllers
         {
             var externalLogin = await signInManager.GetExternalLoginInfoAsync(expectedXsrf);
 
-            var email = externalLogin.Principal.FindFirst(ClaimTypes.Email)?.Value;
+            var email = externalLogin.Principal.TryFindEmail();
 
             if (string.IsNullOrWhiteSpace(email))
             {

--- a/backend/src/Squidex/Config/Authentication/OidcHandler.cs
+++ b/backend/src/Squidex/Config/Authentication/OidcHandler.cs
@@ -40,5 +40,19 @@ namespace Squidex.Config.Authentication
 
             return base.TokenValidated(context);
         }
+
+        public override Task RedirectToIdentityProviderForSignOut(RedirectContext context)
+        {
+            if (!string.IsNullOrEmpty(options.OidcOnSignoutRedirectUrl))
+            {
+                var logoutUri = options.OidcOnSignoutRedirectUrl;
+                context.Response.Redirect(logoutUri);
+                context.HandleResponse();
+
+                return Task.CompletedTask;
+            }
+
+            return base.RedirectToIdentityProviderForSignOut(context);
+        }
     }
 }

--- a/backend/src/Squidex/Config/Authentication/OidcServices.cs
+++ b/backend/src/Squidex/Config/Authentication/OidcServices.cs
@@ -24,8 +24,20 @@ namespace Squidex.Config.Authentication
                     options.Authority = identityOptions.OidcAuthority;
                     options.ClientId = identityOptions.OidcClient;
                     options.ClientSecret = identityOptions.OidcSecret;
-                    options.RequireHttpsMetadata = false;
+                    options.RequireHttpsMetadata = identityOptions.RequiresHttps;
                     options.Events = new OidcHandler(identityOptions);
+
+                    if (!string.IsNullOrEmpty(identityOptions.OidcMetadataAddress))
+                    {
+                        options.MetadataAddress = identityOptions.OidcMetadataAddress;
+                    }
+
+                    if (!string.IsNullOrEmpty(identityOptions.OidcResponseType))
+                    {
+                        options.ResponseType = identityOptions.OidcResponseType;
+                    }
+
+                    options.GetClaimsFromUserInfoEndpoint = identityOptions.OidcGetClaimsFromUserInfoEndpoint;
 
                     if (identityOptions.OidcScopes != null)
                     {

--- a/backend/src/Squidex/Config/MyIdentityOptions.cs
+++ b/backend/src/Squidex/Config/MyIdentityOptions.cs
@@ -47,9 +47,15 @@ namespace Squidex.Config
 
         public string OidcAuthority { get; set; }
 
+        public string OidcMetadataAddress { get; set; }
+
         public string OidcRoleClaimType { get; set; }
 
         public string[] OidcScopes { get; set; }
+
+        public string OidcResponseType { get; set; }
+
+        public bool OidcGetClaimsFromUserInfoEndpoint { get; set; }
 
         public Dictionary<string, string[]> OidcRoleMapping { get; set; }
 

--- a/backend/src/Squidex/Config/MyIdentityOptions.cs
+++ b/backend/src/Squidex/Config/MyIdentityOptions.cs
@@ -59,6 +59,8 @@ namespace Squidex.Config
 
         public Dictionary<string, string[]> OidcRoleMapping { get; set; }
 
+        public string OidcOnSignoutRedirectUrl { get; set; }
+
         public bool AdminRecreate { get; set; }
 
         public bool AllowPasswordAuth { get; set; }

--- a/backend/src/Squidex/appsettings.json
+++ b/backend/src/Squidex/appsettings.json
@@ -654,6 +654,7 @@
     ],
     "oidcResponseType": "id_token", // or "code"
     "oidcGetClaimsFromUserInfoEndpoint": false,
+    "oidcOnSignoutRedirectUrl": "",
 
     /*
      * Lock new users automatically, the administrator must unlock them.

--- a/backend/src/Squidex/appsettings.json
+++ b/backend/src/Squidex/appsettings.json
@@ -648,9 +648,12 @@
     "oidcAuthority": "",
     "oidcClient": "",
     "oidcSecret": "",
+    "oidcMetadataAddress": "",
     "oidcScopes": [
       "email"
     ],
+    "oidcResponseType": "id_token", // or "code"
+    "oidcGetClaimsFromUserInfoEndpoint": false,
 
     /*
      * Lock new users automatically, the administrator must unlock them.


### PR DESCRIPTION
Hello

This PR contains a bugfix and some minor enhanced config/support for the external OIDC feature. It has been designed so that it maintains backwards compatibility and does not change the existing external oidc settings, but allows for some additional config. I have tested it with my oidc server and it works well now, whereas the current config options do not work as our server is a bit quirky.

First the bug.
The recent changes to IdentityServerServices for local config, replacing config in `authBuilder.AddOpenIdConnect` and the line below has an undesirable side-effect - it removes the default IPostConfigureOptions<OpenIdConnectOptions> event meaning that the external oidc config has stopped working because it has not been set up correctly and instead throw errors. I have restored the use of AddOpenIdConnect but with a small hack to acquire the DI container by building it. It is not as elegant but it does seem to work. You may wish to concoct another way of getting the service provider though. Either way it needs fixing - all use of external oidc is currently broken.
```
 authBuilder.Services.AddSingleton<IPostConfigureOptions<OpenIdConnectOptions>>(c => new PostConfigureOptions<OpenIdConnectOptions>(OpenIdConnectDefaults.AuthenticationScheme, options =>
```

I have also added support for external oidc providers who put the email in a claim "email" rather than the existing claim value of ClaimTypes.Email which is "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/email", but have done so as a fallback leaving the current behaviour in place. Otherwise the empty claim generates an exception.

Secondly the new OIDC config.
I have added new oidc variables
* oidcMetadataAddress - enabling OIDC auto discovery. Default to blank/disabled
* oidcResponseType - leave the current id_token default, but allow the user to override it with other options such as "code" required for some OIDC servers
* oidcGetClaimsFromUserInfoEndpoint - tell aspnet to get claims from the oidc server on the backchannel rather than read them from the JWT. existing default of false is maintained
* oidcOnSignoutRedirectUrl - allow you to override the default logout behaviour of redirecting to your oidc server logout url if that is not supported/desirable and specifiy an alternative such as "/". Leaving it blank as the default is means normal oidc logout route is followed.

Please let me know any issues/work required.

Thanks for a great product!

Alastair

