### PR TITLE
bug: fix logout image url

### DIFF
--- a/backend/src/Squidex/Areas/IdentityServer/Views/Account/LogoutCompleted.cshtml
+++ b/backend/src/Squidex/Areas/IdentityServer/Views/Account/LogoutCompleted.cshtml
@@ -2,7 +2,7 @@
     ViewBag.Title = T.Get("users.logout.title");
 }
 
-<img class="splash-image" src="@Url.Content("~/squid.svg?title=BYE%20BYE&text=Hope%20to%20see%20you%20again%20soon!&face=happy")" />
+<img class="splash-image" src="@Url.RootContentUrl("~/squid.svg?title=BYE%20BYE&text=Hope%20to%20see%20you%20again%20soon!&face=happy")" />
 
 <h1 class="splash-h1">@T.Get("users.logout.headline")</h1>
 


### PR DESCRIPTION
Url root is wrong leading to a broken image, e.g. see https://cloud.squidex.io/identity-server/account/logout-completed

![image](https://user-images.githubusercontent.com/6273429/104469995-141dc600-55b1-11eb-8b27-87a73634bf33.png)
