### PR TITLE
Wrong returned type AssetFoldersDto

### DIFF
--- a/backend/src/Squidex/Areas/Api/Controllers/Assets/AssetFoldersController.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Assets/AssetFoldersController.cs
@@ -48,7 +48,7 @@ namespace Squidex.Areas.Api.Controllers.Assets
         /// </remarks>
         [HttpGet]
         [Route("apps/{app}/assets/folders", Order = -1)]
-        [ProducesResponseType(typeof(AssetsDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(AssetFoldersDto), StatusCodes.Status200OK)]
         [ApiPermissionOrAnonymous(Permissions.AppAssetsRead)]
         [ApiCosts(1)]
         public async Task<IActionResult> GetAssetFolders(string app, [FromQuery] DomainId parentId)
@@ -81,7 +81,7 @@ namespace Squidex.Areas.Api.Controllers.Assets
         /// </returns>
         [HttpPost]
         [Route("apps/{app}/assets/folders", Order = -1)]
-        [ProducesResponseType(typeof(AssetDto), 201)]
+        [ProducesResponseType(typeof(AssetFoldersDto), 201)]
         [AssetRequestSizeLimit]
         [ApiPermissionOrAnonymous(Permissions.AppAssetsUpdate)]
         [ApiCosts(1)]
@@ -107,7 +107,7 @@ namespace Squidex.Areas.Api.Controllers.Assets
         /// </returns>
         [HttpPut]
         [Route("apps/{app}/assets/folders/{id}/", Order = -1)]
-        [ProducesResponseType(typeof(AssetDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(AssetFoldersDto), StatusCodes.Status200OK)]
         [AssetRequestSizeLimit]
         [ApiPermissionOrAnonymous(Permissions.AppAssetsUpdate)]
         [ApiCosts(1)]
@@ -133,7 +133,7 @@ namespace Squidex.Areas.Api.Controllers.Assets
         /// </returns>
         [HttpPut]
         [Route("apps/{app}/assets/folders/{id}/parent", Order = -1)]
-        [ProducesResponseType(typeof(AssetDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(AssetFoldersDto), StatusCodes.Status200OK)]
         [AssetRequestSizeLimit]
         [ApiPermissionOrAnonymous(Permissions.AppAssetsUpdate)]
         [ApiCosts(1)]

--- a/backend/src/Squidex/Areas/Api/Controllers/Assets/AssetFoldersController.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Assets/AssetFoldersController.cs
@@ -70,7 +70,7 @@ namespace Squidex.Areas.Api.Controllers.Assets
         }
 
         /// <summary>
-        /// Upload a new asset.
+        /// Upload a new asset folder.
         /// </summary>
         /// <param name="app">The name of the app.</param>
         /// <param name="request">The asset folder object that needs to be added to the App.</param>


### PR DESCRIPTION
This fix an issue with the folders methods: they have wrong documentation about the returned type: it's declared `AssetsDto` but they are returning `AssetFoldersDto`. This produce wrong generated code (e.g. in the C# SDK).

After the merging the C# SDK generated code should be updated.

https://github.com/Squidex/squidex/pull/657 is proposed again (it produces a wrong docs description, and create confusion with another api with the same name)
