### PR TITLE
Change translations flields to 'additionalProperties'

### DIFF
--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
@@ -1,4 +1,4 @@
-﻿// ==========================================================================
+// ==========================================================================
 //  Squidex Headless CMS
 // ==========================================================================
 //  Copyright (c) Squidex UG (haftungsbeschränkt)
@@ -49,31 +49,10 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
             foreach (var field in schema.Fields.ForApi(withHidden))
             {
                 var partitionObject = SchemaBuilder.Object();
-                var partitioning = partitionResolver(field.Partitioning);
 
-                foreach (var partitionKey in partitioning.AllKeys)
-                {
-                    var partitionItemProperty = JsonTypeVisitor.BuildProperty(field, schemaResolver, withHidden);
-
-                    if (partitionItemProperty != null)
-                    {
-                        var isOptional = partitioning.IsOptional(partitionKey);
-
-                        var name = partitioning.GetName(partitionKey);
-
-                        partitionItemProperty.Description = name;
-                        partitionItemProperty.SetRequired(field.RawProperties.IsRequired && !isOptional);
-
-                        partitionObject.Properties.Add(partitionKey, partitionItemProperty);
-                    }
-                }
-
-                if (partitionObject.Properties.Count > 0)
-                {
-                    var propertyReference = schemaResolver($"{schemaName}{field.Name.ToPascalCase()}PropertyDto", () => partitionObject);
-
-                    jsonSchema.Properties.Add(field.Name, CreateProperty(field, propertyReference));
-                }
+                partitionObject.AdditionalPropertiesSchema = JsonTypeVisitor.BuildProperty(field, schemaResolver, withHidden);
+                var propertyReference = schemaResolver($"{schemaName}{field.Name.ToPascalCase()}PropertyDto", () => partitionObject);
+                jsonSchema.Properties.Add(field.Name, CreateProperty(field, propertyReference));
             }
 
             return jsonSchema;

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/GenerateJsonSchema/JsonSchemaTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/GenerateJsonSchema/JsonSchemaTests.cs
@@ -1,4 +1,4 @@
-﻿// ==========================================================================
+// ==========================================================================
 //  Squidex Headless CMS
 // ==========================================================================
 //  Copyright (c) Squidex UG (haftungsbeschränkt)
@@ -116,8 +116,23 @@ namespace Squidex.Domain.Apps.Core.Operations.GenerateJsonSchema
                         }
                     }
 
+                    if (current.AdditionalPropertiesSchema?.Properties != null)
+                    {
+                        foreach (var (key, value) in current.AdditionalPropertiesSchema.Properties)
+                        {
+                            result.Add(key);
+
+                            AddProperties(value);
+                        }
+                    }
+
                     AddProperties(current.Item);
                     AddProperties(current.Reference);
+                    if (current.AdditionalPropertiesSchema is not null)
+                    {
+                        AddProperties(current.AdditionalPropertiesSchema.Item);
+                        AddProperties(current.AdditionalPropertiesSchema.Reference);
+                    }
                 }
             }
 


### PR DESCRIPTION
Base on our conversation here [https://support.squidex.io/t/swagger-nswag-localization-fields-dictionary/2989/5](url) this change should enable generating `Dictionary `for languages properties in NSwag.