### PR TITLE
Open API improvements

### DIFF
--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
@@ -50,7 +50,7 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
                 if (propertyItem != null)
                 {
                     var property =
-                        SchemaBuilder.ObjectMapProperty(propertyItem)
+                        SchemaBuilder.ObjectProperty(propertyItem)
                             .SetDescription(field)
                             .SetRequired(field.RawProperties.IsRequired);
 
@@ -99,10 +99,10 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
             return jsonSchema;
         }
 
-        public static JsonSchemaProperty CreateProperty(IField field, JsonSchema? reference)
+        public static JsonSchemaProperty CreateProperty(IField field, JsonSchema reference)
         {
             var jsonProperty =
-                SchemaBuilder.ObjectProperty(reference)
+                SchemaBuilder.ReferenceProperty(reference)
                     .SetDescription(field)
                     .SetRequired(field.RawProperties.IsRequired);
 

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
@@ -14,7 +14,7 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 {
     public static class JsonSchemaExtensions
     {
-        public static JsonSchema BuildFlatJsonSchema(this Schema schema, SchemaResolver schemaResolver, bool withHidden = false)
+        public static JsonSchema BuildFlatJsonSchema(this Schema schema, SchemaResolver schemaResolver)
         {
             Guard.NotNull(schemaResolver, nameof(schemaResolver));
 
@@ -22,9 +22,9 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
             var jsonSchema = SchemaBuilder.Object();
 
-            foreach (var field in schema.Fields.ForApi(withHidden))
+            foreach (var field in schema.Fields.ForApi())
             {
-                var property = JsonTypeVisitor.BuildProperty(field, schemaResolver, withHidden);
+                var property = JsonTypeVisitor.BuildProperty(field, false);
 
                 if (property != null)
                 {
@@ -37,52 +37,80 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
             return jsonSchema;
         }
 
-        public static JsonSchema BuildJsonSchema(this Schema schema, PartitionResolver partitionResolver, SchemaResolver schemaResolver, bool withHidden = false)
+        public static JsonSchema BuildDynamicJsonSchema(this Schema schema, SchemaResolver schemaResolver, bool withHidden = false)
         {
             Guard.NotNull(schemaResolver, nameof(schemaResolver));
-            Guard.NotNull(partitionResolver, nameof(partitionResolver));
-
-            var schemaName = schema.TypeName();
 
             var jsonSchema = SchemaBuilder.Object();
 
             foreach (var field in schema.Fields.ForApi(withHidden))
             {
-                var partitionObject = SchemaBuilder.Object();
-                var partitioning = partitionResolver(field.Partitioning);
+                var propertyItem = JsonTypeVisitor.BuildProperty(field, withHidden);
 
-                foreach (var partitionKey in partitioning.AllKeys)
+                if (propertyItem != null)
                 {
-                    var partitionItemProperty = JsonTypeVisitor.BuildProperty(field, schemaResolver, withHidden);
+                    var property =
+                        SchemaBuilder.ObjectMapProperty(propertyItem)
+                            .SetDescription(field)
+                            .SetRequired(field.RawProperties.IsRequired);
 
-                    if (partitionItemProperty != null)
-                    {
-                        var isOptional = partitioning.IsOptional(partitionKey);
-
-                        var name = partitioning.GetName(partitionKey);
-
-                        partitionItemProperty.Description = name;
-                        partitionItemProperty.SetRequired(field.RawProperties.IsRequired && !isOptional);
-
-                        partitionObject.Properties.Add(partitionKey, partitionItemProperty);
-                    }
-                }
-
-                if (partitionObject.Properties.Count > 0)
-                {
-                    var propertyReference = schemaResolver($"{schemaName}{field.Name.ToPascalCase()}PropertyDto", () => partitionObject);
-
-                    jsonSchema.Properties.Add(field.Name, CreateProperty(field, propertyReference));
+                    jsonSchema.Properties.Add(field.Name, property);
                 }
             }
 
             return jsonSchema;
         }
 
-        public static JsonSchemaProperty CreateProperty(IField field, JsonSchema reference)
+        public static JsonSchema BuildJsonSchema(this Schema schema, PartitionResolver partitionResolver, bool withHidden = false)
         {
-            var jsonProperty = SchemaBuilder.ObjectProperty(reference);
+            Guard.NotNull(partitionResolver, nameof(partitionResolver));
 
+            var jsonSchema = SchemaBuilder.Object();
+
+            foreach (var field in schema.Fields.ForApi(withHidden))
+            {
+                var propertyObject = SchemaBuilder.Object();
+
+                var partitioning = partitionResolver(field.Partitioning);
+
+                foreach (var partitionKey in partitioning.AllKeys)
+                {
+                    var propertyItem = JsonTypeVisitor.BuildProperty(field, withHidden);
+
+                    if (propertyItem != null)
+                    {
+                        var isOptional = partitioning.IsOptional(partitionKey);
+
+                        var name = partitioning.GetName(partitionKey);
+
+                        propertyItem.SetDescription(name);
+                        propertyItem.SetRequired(field.RawProperties.IsRequired && !isOptional);
+
+                        propertyObject.Properties.Add(partitionKey, propertyItem);
+                    }
+                }
+
+                if (propertyObject.Properties.Count > 0)
+                {
+                    jsonSchema.Properties.Add(field.Name, CreateProperty(field, propertyObject));
+                }
+            }
+
+            return jsonSchema;
+        }
+
+        public static JsonSchemaProperty CreateProperty(IField field, JsonSchema? reference)
+        {
+            var jsonProperty =
+                SchemaBuilder.ObjectProperty(reference)
+                    .SetDescription(field)
+                    .SetRequired(field.RawProperties.IsRequired);
+
+            return jsonProperty;
+        }
+
+        private static JsonSchemaProperty SetDescription(this JsonSchemaProperty jsonProperty, IField field)
+        {
             if (!string.IsNullOrWhiteSpace(field.RawProperties.Hints))
             {
                 jsonProperty.Description = $"{field.Name} ({field.RawProperties.Hints})";
@@ -91,8 +119,6 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
             {
                 jsonProperty.Description = field.Name;
             }
-
-            jsonProperty.SetRequired(field.RawProperties.IsRequired);
 
             return jsonProperty;
         }

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonSchemaExtensions.cs
@@ -24,7 +24,7 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
             foreach (var field in schema.Fields.ForApi())
             {
-                var property = JsonTypeVisitor.BuildProperty(field, false);
+                var property = JsonTypeVisitor.BuildProperty(field, null, false);
 
                 if (property != null)
                 {
@@ -45,7 +45,7 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
             foreach (var field in schema.Fields.ForApi(withHidden))
             {
-                var propertyItem = JsonTypeVisitor.BuildProperty(field, withHidden);
+                var propertyItem = JsonTypeVisitor.BuildProperty(field, null, withHidden);
 
                 if (propertyItem != null)
                 {
@@ -75,7 +75,7 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
                 foreach (var partitionKey in partitioning.AllKeys)
                 {
-                    var propertyItem = JsonTypeVisitor.BuildProperty(field, withHidden);
+                    var propertyItem = JsonTypeVisitor.BuildProperty(field, null, withHidden);
 
                     if (propertyItem != null)
                     {

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonTypeVisitor.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonTypeVisitor.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.ObjectModel;
 using NJsonSchema;
 using Squidex.Domain.Apps.Core.Schemas;
-using Squidex.Infrastructure.Json;
 
 namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 {
@@ -77,7 +76,7 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
         public JsonSchemaProperty? Visit(IField<GeolocationFieldProperties> field, Args args)
         {
-            return SchemaBuilder.JsonProperty();
+            return SchemaBuilder.ObjectProperty(null);
         }
 
         public JsonSchemaProperty? Visit(IField<JsonFieldProperties> field, Args args)

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonTypeVisitor.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonTypeVisitor.cs
@@ -76,7 +76,7 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
         public JsonSchemaProperty? Visit(IField<GeolocationFieldProperties> field, Args args)
         {
-            return SchemaBuilder.ObjectProperty(null);
+            return SchemaBuilder.ObjectProperty();
         }
 
         public JsonSchemaProperty? Visit(IField<JsonFieldProperties> field, Args args)

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonTypeVisitor.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/JsonTypeVisitor.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.ObjectModel;
 using NJsonSchema;
 using Squidex.Domain.Apps.Core.Schemas;
+using Squidex.Infrastructure.Json;
 
 namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 {
@@ -76,7 +77,11 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
         public JsonSchemaProperty? Visit(IField<GeolocationFieldProperties> field, Args args)
         {
-            return SchemaBuilder.ObjectProperty();
+            var property = SchemaBuilder.ObjectProperty();
+
+            property.Format = GeoJson.Format;
+
+            return property;
         }
 
         public JsonSchemaProperty? Visit(IField<JsonFieldProperties> field, Args args)

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/SchemaBuilder.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/SchemaBuilder.cs
@@ -56,14 +56,14 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
                 .SetRequired(isRequired);
         }
 
-        public static JsonSchemaProperty ObjectProperty(JsonSchema? reference, string? description = null, bool isRequired = false)
+        public static JsonSchemaProperty ReferenceProperty(JsonSchema reference, string? description = null, bool isRequired = false)
         {
             return new JsonSchemaProperty { Reference = reference }
                 .SetDescription(description)
                 .SetRequired(isRequired);
         }
 
-        public static JsonSchemaProperty ObjectMapProperty(JsonSchema? value, string? description = null, bool isRequired = false)
+        public static JsonSchemaProperty ObjectProperty(JsonSchema? value = null, string? description = null, bool isRequired = false)
         {
             return new JsonSchemaProperty { Type = JsonObjectType.Object, AdditionalPropertiesSchema = value }
                 .SetDescription(description)

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/SchemaBuilder.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/GenerateJsonSchema/SchemaBuilder.cs
@@ -23,48 +23,68 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
         public static JsonSchemaProperty ArrayProperty(JsonSchema item, string? description = null, bool isRequired = false)
         {
-            return Enrich(new JsonSchemaProperty { Type = JsonObjectType.Array, Item = item }, description, isRequired);
+            return new JsonSchemaProperty { Type = JsonObjectType.Array, Item = item }
+                .SetDescription(description)
+                .SetRequired(isRequired);
         }
 
         public static JsonSchemaProperty BooleanProperty(string? description = null, bool isRequired = false)
         {
-            return Enrich(new JsonSchemaProperty { Type = JsonObjectType.Boolean }, description, isRequired);
+            return new JsonSchemaProperty { Type = JsonObjectType.Boolean }
+                .SetDescription(description)
+                .SetRequired(isRequired);
         }
 
         public static JsonSchemaProperty DateTimeProperty(string? description = null, bool isRequired = false)
         {
-            return Enrich(new JsonSchemaProperty { Type = JsonObjectType.String, Format = JsonFormatStrings.DateTime }, description, isRequired);
+            return new JsonSchemaProperty { Type = JsonObjectType.String, Format = JsonFormatStrings.DateTime }
+                .SetDescription(description)
+                .SetRequired(isRequired);
         }
 
         public static JsonSchemaProperty NumberProperty(string? description = null, bool isRequired = false)
         {
-            return Enrich(new JsonSchemaProperty { Type = JsonObjectType.Number }, description, isRequired);
+            return new JsonSchemaProperty { Type = JsonObjectType.Number }
+                .SetDescription(description)
+                .SetRequired(isRequired);
         }
 
         public static JsonSchemaProperty StringProperty(string? description = null, bool isRequired = false)
         {
-            return Enrich(new JsonSchemaProperty { Type = JsonObjectType.String }, description, isRequired);
+            return new JsonSchemaProperty { Type = JsonObjectType.String }
+                .SetDescription(description)
+                .SetRequired(isRequired);
         }
 
-        public static JsonSchemaProperty ObjectProperty(JsonSchema reference, string? description = null, bool isRequired = false)
+        public static JsonSchemaProperty ObjectProperty(JsonSchema? reference, string? description = null, bool isRequired = false)
         {
-            return Enrich(new JsonSchemaProperty { Reference = reference }, description, isRequired);
+            return new JsonSchemaProperty { Reference = reference }
+                .SetDescription(description)
+                .SetRequired(isRequired);
+        }
+
+        public static JsonSchemaProperty ObjectMapProperty(JsonSchema? value, string? description = null, bool isRequired = false)
+        {
+            return new JsonSchemaProperty { Type = JsonObjectType.Object, AdditionalPropertiesSchema = value }
+                .SetDescription(description)
+                .SetRequired(isRequired);
         }
 
         public static JsonSchemaProperty JsonProperty(string? description = null, bool isRequired = false)
         {
-            return Enrich(new JsonSchemaProperty(), description, isRequired);
+            return new JsonSchemaProperty()
+                .SetDescription(description)
+                .SetRequired(isRequired);
         }
 
-        private static JsonSchemaProperty Enrich(JsonSchemaProperty property, string? description = null, bool isRequired = false)
+        public static T SetDescription<T>(this T property, string? description = null) where T : JsonSchemaProperty
         {
             property.Description = description;
-            property.SetRequired(isRequired);
 
             return property;
         }
 
-        public static JsonSchemaProperty SetRequired(this JsonSchemaProperty property, bool isRequired)
+        public static T SetRequired<T>(this T property, bool isRequired) where T : JsonSchemaProperty
         {
             property.IsRequired = isRequired;
             property.IsNullableRaw = !isRequired;

--- a/backend/src/Squidex.Domain.Apps.Entities/Contents/Queries/ContentQueryParser.cs
+++ b/backend/src/Squidex.Domain.Apps.Entities/Contents/Queries/ContentQueryParser.cs
@@ -235,7 +235,7 @@ namespace Squidex.Domain.Apps.Entities.Contents.Queries
 
         private static JsonSchema BuildJsonSchema(Schema schema, IAppEntity app, bool withHiddenFields)
         {
-            var dataSchema = schema.BuildJsonSchema(app.PartitionResolver(), (n, action) => action(), withHiddenFields);
+            var dataSchema = schema.BuildJsonSchema(app.PartitionResolver(), withHiddenFields);
 
             return ContentJsonSchemaBuilder.BuildSchema(schema.DisplayName(), dataSchema);
         }

--- a/backend/src/Squidex.Domain.Apps.Entities/Contents/Schemas/ContentJsonSchemaBuilder.cs
+++ b/backend/src/Squidex.Domain.Apps.Entities/Contents/Schemas/ContentJsonSchemaBuilder.cs
@@ -38,8 +38,8 @@ namespace Squidex.Domain.Apps.Core.GenerateJsonSchema
 
             if (dataSchema != null)
             {
-                jsonSchema.Properties["data"] = SchemaBuilder.ObjectProperty(dataSchema, $"The data of the {name}.", true);
-                jsonSchema.Properties["dataDraft"] = SchemaBuilder.ObjectProperty(dataSchema, $"The draft data of the {name}.");
+                jsonSchema.Properties["data"] = SchemaBuilder.ReferenceProperty(dataSchema, $"The data of the {name}.", true);
+                jsonSchema.Properties["dataDraft"] = SchemaBuilder.ReferenceProperty(dataSchema, $"The draft data of the {name}.");
             }
 
             return jsonSchema;

--- a/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/Builder.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/Builder.cs
@@ -11,7 +11,6 @@ using NJsonSchema;
 using NSwag;
 using NSwag.Generation;
 using Squidex.Areas.Api.Controllers.Contents.Models;
-using Squidex.Domain.Apps.Core;
 using Squidex.Domain.Apps.Core.GenerateJsonSchema;
 using Squidex.Domain.Apps.Core.Schemas;
 using Squidex.Domain.Apps.Entities.Apps;

--- a/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/OperationsBuilder.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/OperationsBuilder.cs
@@ -27,6 +27,8 @@ namespace Squidex.Areas.Api.Controllers.Contents.Generator
 
         public JsonSchema ContentSchema { get; init; }
 
+        public JsonSchema ContentsSchema { get; init; }
+
         public JsonSchema DataSchema { get; init; }
 
         public string FormatText(string text)

--- a/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/SchemasOpenApiGenerator.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/SchemasOpenApiGenerator.cs
@@ -82,28 +82,24 @@ namespace Squidex.Areas.Api.Controllers.Contents.Generator
 
         private static void GenerateSharedOperations(OperationsBuilder builder)
         {
-            var contentsSchema = BuildResults(builder);
-
             builder.AddOperation(OpenApiOperationMethod.Get, "/")
                 .RequirePermission(Permissions.AppContentsReadOwn)
                 .Operation("Query")
                 .OperationSummary("Query contents across all schemas.")
                 .HasQuery("ids", JsonObjectType.String, "Comma-separated list of content IDs.")
-                .Responds(200, "Content items retrieved.", contentsSchema)
+                .Responds(200, "Content items retrieved.", builder.ContentsSchema)
                 .Responds(400, "Query not valid.");
         }
 
         private static void GenerateSchemaOperations(OperationsBuilder builder)
         {
-            var contentsSchema = BuildResults(builder);
-
             builder.AddOperation(OpenApiOperationMethod.Get, "/")
                 .RequirePermission(Permissions.AppContentsReadOwn)
                 .Operation("Query")
                 .OperationSummary("Query schema contents items.")
                 .Describe(Properties.Resources.OpenApiSchemaQuery)
                 .HasQueryOptions(true)
-                .Responds(200, "Content items retrieved.", contentsSchema)
+                .Responds(200, "Content items retrieved.", builder.ContentsSchema)
                 .Responds(400, "Query not valid.");
 
             builder.AddOperation(OpenApiOperationMethod.Get, "/{id}")
@@ -190,19 +186,6 @@ namespace Squidex.Areas.Api.Controllers.Contents.Generator
                 .OperationSummary("Delete a schema content item.")
                 .HasId()
                 .Responds(204, "Content item deleted");
-        }
-
-        private static JsonSchema BuildResults(OperationsBuilder builder)
-        {
-            return new JsonSchema
-            {
-                Properties =
-                {
-                    ["total"] = SchemaBuilder.NumberProperty("The total number of content items.", true),
-                    ["items"] = SchemaBuilder.ArrayProperty(builder.ContentSchema, "The content items.", true)
-                },
-                Type = JsonObjectType.Object
-            };
         }
 
         private OpenApiDocument CreateApiDocument(HttpContext context, IAppEntity app)

--- a/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/SchemasOpenApiGenerator.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Contents/Generator/SchemasOpenApiGenerator.cs
@@ -13,7 +13,6 @@ using NJsonSchema;
 using NSwag;
 using NSwag.Generation;
 using NSwag.Generation.Processors.Contexts;
-using Squidex.Domain.Apps.Core.GenerateJsonSchema;
 using Squidex.Domain.Apps.Entities.Apps;
 using Squidex.Domain.Apps.Entities.Schemas;
 using Squidex.Hosting;

--- a/backend/src/Squidex/Config/Domain/CommandsServices.cs
+++ b/backend/src/Squidex/Config/Domain/CommandsServices.cs
@@ -23,7 +23,6 @@ using Squidex.Domain.Apps.Entities.Schemas.Commands;
 using Squidex.Domain.Apps.Entities.Schemas.DomainObject;
 using Squidex.Domain.Apps.Entities.Schemas.Indexes;
 using Squidex.Infrastructure.Commands;
-using Squidex.Infrastructure.EventSourcing;
 using Squidex.Web.CommandMiddlewares;
 
 namespace Squidex.Config.Domain

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/GenerateJsonSchema/JsonSchemaTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/GenerateJsonSchema/JsonSchemaTests.cs
@@ -56,7 +56,7 @@ namespace Squidex.Domain.Apps.Core.Operations.GenerateJsonSchema
             CheckFields(jsonSchema);
         }
 
-        private void CheckFields(JsonSchema jsonSchema, params string[] exclude)
+        private void CheckFields(JsonSchema jsonSchema)
         {
             var jsonProperties = AllPropertyNames(jsonSchema);
 
@@ -75,20 +75,14 @@ namespace Squidex.Domain.Apps.Core.Operations.GenerateJsonSchema
                 {
                     foreach (var nested in array.Fields)
                     {
-                        if (!exclude.Contains(nested.Name))
-                        {
-                            CheckField(nested);
-                        }
+                        CheckField(nested);
                     }
                 }
             }
 
             foreach (var field in schema.Fields)
             {
-                if (!exclude.Contains(field.Name))
-                {
-                    CheckField(field);
-                }
+                CheckField(field);
             }
         }
 

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/GenerateJsonSchema/JsonSchemaTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/GenerateJsonSchema/JsonSchemaTests.cs
@@ -6,6 +6,7 @@
 // ==========================================================================
 
 using System.Collections.Generic;
+using System.Linq;
 using NJsonSchema;
 using Squidex.Domain.Apps.Core.Apps;
 using Squidex.Domain.Apps.Core.GenerateJsonSchema;
@@ -25,38 +26,19 @@ namespace Squidex.Domain.Apps.Core.Operations.GenerateJsonSchema
         {
             var languagesConfig = LanguagesConfig.English.Set(Language.DE);
 
-            var schemaResolver = new SchemaResolver((name, action) =>
-            {
-                return action();
-            });
+            var jsonSchema = schema.BuildJsonSchema(languagesConfig.ToResolver());
 
-            var jsonSchema = schema.BuildJsonSchema(languagesConfig.ToResolver(), schemaResolver);
-            var jsonProperties = AllPropertyNames(jsonSchema);
+            CheckFields(jsonSchema);
+        }
 
-            void CheckField(IField field)
-            {
-                if (!field.IsForApi())
-                {
-                    Assert.DoesNotContain(field.Name, jsonProperties);
-                }
-                else
-                {
-                    Assert.Contains(field.Name, jsonProperties);
-                }
+        [Fact]
+        public void Should_build_json_schema_with_resolver()
+        {
+            var schemaResolver = new SchemaResolver((name, action) => action());
 
-                if (field is IArrayField array)
-                {
-                    foreach (var nested in array.Fields)
-                    {
-                        CheckField(nested);
-                    }
-                }
-            }
+            var jsonSchema = schema.BuildDynamicJsonSchema(schemaResolver);
 
-            foreach (var field in schema.Fields)
-            {
-                CheckField(field);
-            }
+            CheckFields(jsonSchema);
         }
 
         [Fact]
@@ -70,6 +52,12 @@ namespace Squidex.Domain.Apps.Core.Operations.GenerateJsonSchema
             });
 
             var jsonSchema = schema.BuildFlatJsonSchema(schemaResolver);
+
+            CheckFields(jsonSchema);
+        }
+
+        private void CheckFields(JsonSchema jsonSchema, params string[] exclude)
+        {
             var jsonProperties = AllPropertyNames(jsonSchema);
 
             void CheckField(IField field)
@@ -87,14 +75,20 @@ namespace Squidex.Domain.Apps.Core.Operations.GenerateJsonSchema
                 {
                     foreach (var nested in array.Fields)
                     {
-                        CheckField(nested);
+                        if (!exclude.Contains(nested.Name))
+                        {
+                            CheckField(nested);
+                        }
                     }
                 }
             }
 
             foreach (var field in schema.Fields)
             {
-                CheckField(field);
+                if (!exclude.Contains(field.Name))
+                {
+                    CheckField(field);
+                }
             }
         }
 
@@ -118,6 +112,8 @@ namespace Squidex.Domain.Apps.Core.Operations.GenerateJsonSchema
 
                     AddProperties(current.Item);
                     AddProperties(current.Reference);
+                    AddProperties(current.AdditionalItemsSchema);
+                    AddProperties(current.AdditionalPropertiesSchema);
                 }
             }
 

--- a/backend/tests/Squidex.Infrastructure.Tests/Commands/DomainObjectTests.cs
+++ b/backend/tests/Squidex.Infrastructure.Tests/Commands/DomainObjectTests.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using FakeItEasy;
 using Squidex.Infrastructure.EventSourcing;


### PR DESCRIPTION
A few OpenAPI improvements

* Just returns a "any" JSON for Geolocation fields, because they can be more dynamic now.
* Use normal maps for fields to make code generation easier.
* Ensure that unneeded schemas are not part of the output.
* Give result objects (items, total) a name so that they look better in generated code.