### PR TITLE
Revert back to agnostic tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Stage 1, Build Backend
 #
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim as backend
+FROM mcr.microsoft.com/dotnet/sdk:5.0 as backend
 
 ARG SQUIDEX__VERSION=4.0.0
 


### PR DESCRIPTION
- `.102-ca-patch-buster-slim` is no longer serviced
- The latest `5.0` patch has related fixes.

Context: https://github.com/dotnet/announcements/issues/180