### PR TITLE
reordering services configuration

### DIFF
--- a/backend/src/Squidex/Startup.cs
+++ b/backend/src/Squidex/Startup.cs
@@ -38,14 +38,13 @@ namespace Squidex
             services.AddMemoryCache();
             services.AddNonBreakingSameSiteCookies();
 
-            services.AddSquidexMvcWithPlugins(config);
-
             services.AddSquidexApps();
             services.AddSquidexAssetInfrastructure(config);
             services.AddSquidexAssets(config);
             services.AddSquidexAuthentication(config);
             services.AddSquidexBackups();
             services.AddSquidexCommands(config);
+            services.AddSquidexMvcWithPlugins(config);
             services.AddSquidexComments();
             services.AddSquidexContents(config);
             services.AddSquidexControllerServices(config);


### PR DESCRIPTION
Hello,

Using plugin for application template fails when executing the creation commands

During HandleAsync, context.IsCompleted is false and prevents the creation to be handled
```
public async Task HandleAsync(CommandContext context, NextDelegate next)
{
      if (context.IsCompleted && context.Command is CreateApp createApp && IsRightTemplate(createApp))

```

To be specific, it seems that `services.AddSquidexMvcWithPlugins(config);` needs to be called after 
```
            services.AddSingletonAs<SingletonCommandMiddleware>()
                .As<ICommandMiddleware>();
```
in CommandsServices.cs, thus we moved `AddSquidexMvcWithPlugins` after `AddSquidexCommands`

We're not fully aware of potential side effect this request could have. 
It works for our template applications plugins.

Regards