### PR TITLE
Fix issue with tag retrieval

### DIFF
--- a/backend/src/Squidex/Areas/Api/Controllers/Schemas/Models/SchemaPropertiesDto.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Schemas/Models/SchemaPropertiesDto.cs
@@ -5,7 +5,7 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
-using System.Collections.Immutable;
+using Squidex.Infrastructure.Collections;
 using Squidex.Infrastructure.Validation;
 
 namespace Squidex.Areas.Api.Controllers.Schemas.Models


### PR DESCRIPTION
- Align schemaproperties tags property type for correct map later in pipe

Just to be more specific. If now user tries to save "Schema" tags - saved tags are not returned and tags field is always empty. That's because SchemaProperties uses custom ImmutableList, while SchemaPropertiesDto - uses standard .NET immutablelist.
This model alignment will allow SimpleMapper to convert tags correctly