### PR TITLE
Replace overflow overlay with auto

### DIFF
--- a/frontend/app/framework/angular/list-view.component.scss
+++ b/frontend/app/framework/angular/list-view.component.scss
@@ -29,7 +29,7 @@
 
         &.normal {
             overflow-x: hidden;
-            overflow-y: overlay;
+            overflow-y: auto;
         }
 
         .inner {

--- a/frontend/app/theme/_panels2.scss
+++ b/frontend/app/theme/_panels2.scss
@@ -224,7 +224,7 @@
             }
 
             &.overflow {
-                overflow-y: overlay;
+                overflow-y: auto;
             }
         }
 


### PR DESCRIPTION
Since overflow "overlay" doesn't seem to be supported in all browsers I replaced it with "auto" because I can't scroll the left panel when having too many schemas defined.

See: https://caniuse.com/css-overflow-overlay