### PR TITLE
Reference item schema label hover minor enhancement

### DIFF
--- a/frontend/app/features/content/shared/references/reference-item.component.scss
+++ b/frontend/app/features/content/shared/references/reference-item.component.scss
@@ -19,3 +19,17 @@
 .badge {
     @include truncate;
 }
+
+.cell-label {
+    &:hover {
+        position: relative;
+
+        .badge {
+            max-width: 500px;
+            position: absolute;
+            right: .75rem;
+            top: 1.25rem;
+            width: auto;
+        }
+    }
+}


### PR DESCRIPTION
Default view
![image](https://user-images.githubusercontent.com/292720/139827092-180e5003-efd0-4c62-96b0-fa71952a1c0c.png)


Before with title attribute
![image](https://user-images.githubusercontent.com/292720/139827015-4e298483-be6e-454c-8a4e-88e9baf0f869.png)

After, with hover and expand. We found some users wanted to copy schema names, this allows it.
![image](https://user-images.githubusercontent.com/292720/139826746-c9ca34d6-193e-4061-898a-792dfa1b5e75.png)
![image](https://user-images.githubusercontent.com/292720/139827191-2bacb5a0-f861-48d7-acb2-c5edc1a13159.png)



