### PR TITLE
Fix for setting image height and width metadata

### DIFF
--- a/backend/src/Squidex.Domain.Apps.Entities/Assets/FileTagAssetMetadataSource.cs
+++ b/backend/src/Squidex.Domain.Apps.Entities/Assets/FileTagAssetMetadataSource.cs
@@ -77,7 +77,7 @@ namespace Squidex.Domain.Apps.Entities.Assets
                     var pw = file.Properties.PhotoWidth;
                     var ph = file.Properties.PhotoHeight;
 
-                    if (pw > 0 && pw > 0)
+                    if (pw > 0 && ph > 0)
                     {
                         command.Metadata.SetPixelWidth(pw);
                         command.Metadata.SetPixelHeight(ph);

--- a/backend/tests/Squidex.Domain.Apps.Entities.Tests/Assets/FileTagAssetMetadataSourceTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Entities.Tests/Assets/FileTagAssetMetadataSourceTests.cs
@@ -41,6 +41,17 @@ namespace Squidex.Domain.Apps.Entities.Assets
         }
 
         [Fact]
+        public async Task Should_not_set_image_height_and_width_metadata_when_file_does_not_have_those_values()
+        {
+            var command = Command("SampleAudio_0.4mb.mp3");
+
+            await sut.EnhanceAsync(command);
+
+            Assert.Null(command.Metadata.GetPixelWidth());
+            Assert.Null(command.Metadata.GetPixelHeight());
+        }
+
+        [Fact]
         public async Task Should_provide_metadata_for_audio()
         {
             var command = Command("SampleAudio_0.4mb.mp3");


### PR DESCRIPTION
This was raised by SonarQube; it detected identical expressions on both sides of the operator.

Was unable to create test files where just one of these properties is 0 so test may have limited/no value.