### PR TITLE
Client and server side Field Hint length validation now in sync

### DIFF
--- a/backend/src/Squidex/Areas/Api/Controllers/Schemas/Models/FieldPropertiesDto.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/Schemas/Models/FieldPropertiesDto.cs
@@ -25,7 +25,7 @@ namespace Squidex.Areas.Api.Controllers.Schemas.Models
         public string? Label { get; set; }
 
         /// <summary>
-        /// Hints to describe the schema.
+        /// Hints to describe the field.
         /// </summary>
         [LocalizedStringLength(1000)]
         public string? Hints { get; set; }

--- a/frontend/src/app/features/schemas/pages/schema/fields/forms/field-form-common.component.html
+++ b/frontend/src/app/features/schemas/pages/schema/fields/forms/field-form-common.component.html
@@ -31,7 +31,7 @@
         <div class="col-9">
             <sqx-control-errors for="hints"></sqx-control-errors>
 
-            <input type="text" class="form-control" id="{{field.fieldId}}_fieldHints" maxlength="100" formControlName="hints">
+            <input type="text" class="form-control" id="{{field.fieldId}}_fieldHints" maxlength="1000" formControlName="hints">
 
             <sqx-form-hint>
                 {{ 'schemas.field.hintsHint' | sqxTranslate }}


### PR DESCRIPTION
I was getting requests to add hints longer than a 100 characters to fields so was going to raise a feature request to increase the limit, but then I noticed the server side validation does allow 1000 characters so I believe this should be OK?

If this change is valid should the editor now be a text area instead of an input much like the schema hint field?