### PR TITLE
RBAC updates to support aggregated role bindings

### DIFF
--- a/backend/src/Squidex/Config/Authentication/OidcHandler.cs
+++ b/backend/src/Squidex/Config/Authentication/OidcHandler.cs
@@ -26,12 +26,8 @@ namespace Squidex.Config.Authentication
 
             if (!string.IsNullOrWhiteSpace(options.OidcRoleClaimType) && options.OidcRoleMapping?.Count >= 0)
             {
-                var roles = identity
-                    .FindAll(c => c.Type == options.OidcRoleClaimType)
-                    .Select(c => c.Value);
-
                 var permissions = options.OidcRoleMapping
-                    .Where(r => roles.Contains(r.Key))
+                    .Where(r => identity.HasClaim(options.OidcRoleClaimType, r.Key))
                     .SelectMany(r => r.Value)
                     .Distinct();
 

--- a/backend/src/Squidex/Config/Authentication/OidcHandler.cs
+++ b/backend/src/Squidex/Config/Authentication/OidcHandler.cs
@@ -24,7 +24,8 @@ namespace Squidex.Config.Authentication
         {
             var identity = (ClaimsIdentity)context.Principal!.Identity!;
 
-            if (!string.IsNullOrWhiteSpace(options.OidcRoleClaimType) && options.OidcRoleMapping?.Count >= 0) {
+            if (!string.IsNullOrWhiteSpace(options.OidcRoleClaimType) && options.OidcRoleMapping?.Count >= 0)
+            {
                 var roles = identity
                     .FindAll(c => c.Type == options.OidcRoleClaimType)
                     .Select(c => c.Value);
@@ -34,7 +35,8 @@ namespace Squidex.Config.Authentication
                     .SelectMany(r => r.Value)
                     .Distinct();
 
-                foreach (var permission in permissions) {
+                foreach (var permission in permissions)
+                {
                     identity.AddClaim(new Claim(SquidexClaimTypes.Permissions, permission));
                 }
             }


### PR DESCRIPTION
RBAC updates to support aggregated role bindings when using the OidcRoleMapping with an external identity provider.

See https://support.squidex.io/t/support-multiple-roles-in-oidc-role-mapping/4166 for more details regarding this change.