### PR TITLE
Skip insert operation if the entity collection is empty

### DIFF
--- a/backend/src/Squidex.Domain.Apps.Entities.MongoDb/Contents/MongoContentCollection.cs
+++ b/backend/src/Squidex.Domain.Apps.Entities.MongoDb/Contents/MongoContentCollection.cs
@@ -230,7 +230,9 @@ namespace Squidex.Domain.Apps.Entities.MongoDb.Contents
         public Task InsertManyAsync(IReadOnlyList<MongoContentEntity> snapshots,
             CancellationToken ct = default)
         {
-            return Collection.InsertManyAsync(snapshots, InsertUnordered, ct);
+            return !snapshots.Any()
+                ? Task.CompletedTask
+                : Collection.InsertManyAsync(snapshots, InsertUnordered, ct);
         }
     }
 }


### PR DESCRIPTION
https://support.squidex.io/t/regression-backups-can-no-longer-be-restored/4349