### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2.5.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Check for Update
-        uses: saadmk11/github-actions-version-updater@v0.5.6
+        uses: saadmk11/github-actions-version-updater@v0.7.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Calculate Version
         env:
@@ -28,13 +28,13 @@ jobs:
           echo "BUILD_NUMBER=$(($BUILD_NUMBER + 5967))" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: BUILD
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.2.0
         with:
           push: false
           load: true
@@ -55,7 +55,7 @@ jobs:
         run: docker save squidex-tmp | gzip > squidex-tmp.tar.gz
 
       - name: Save Image to Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: squidex-tmp.tar.gz
           key: squidex-dev-image-${{ github.sha }}
@@ -76,13 +76,13 @@ jobs:
           echo "BUILD_NUMBER=$(($BUILD_NUMBER + 5967))" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Get Image From Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: squidex-tmp.tar.gz
           key: squidex-dev-image-${{ github.sha }}
@@ -91,17 +91,17 @@ jobs:
         run: docker load < squidex-tmp.tar.gz
 
       - name: Replace Image Name1
-        uses: mikefarah/yq@v4.9.1
+        uses: mikefarah/yq@v4.28.2
         with:
           cmd: yq e '.services.squidex1.image = "squidex-tmp"' -i backend/tests/docker-compose.yml
 
       - name: Replace Image Name2
-        uses: mikefarah/yq@v4.9.1
+        uses: mikefarah/yq@v4.28.2
         with:
           cmd: yq e '.services.squidex2.image = "squidex-tmp"' -i backend/tests/docker-compose.yml
 
       - name: Replace Image Name3
-        uses: mikefarah/yq@v4.9.1
+        uses: mikefarah/yq@v4.28.2
         with:
           cmd: yq e '.services.squidex3.image = "squidex-tmp"' -i backend/tests/docker-compose.yml
 
@@ -110,7 +110,7 @@ jobs:
         working-directory: backend/tests
 
       - name: RUN TEST
-        uses: kohlerdominik/docker-run-action@v1
+        uses: kohlerdominik/docker-run-action@v1.0.2
         with:
           image: squidex/build
           environment: |
@@ -124,7 +124,7 @@ jobs:
           run: dotnet test /src/backend/tools/TestSuite/TestSuite.ApiTests/TestSuite.ApiTests.csproj --filter Category!=NotAutomated
 
       - name: RUN TEST on path
-        uses: kohlerdominik/docker-run-action@v1
+        uses: kohlerdominik/docker-run-action@v1.0.2
         with:
           image: squidex/build
           environment: |
@@ -138,7 +138,7 @@ jobs:
           run: dotnet test /src/backend/tools/TestSuite/TestSuite.ApiTests/TestSuite.ApiTests.csproj --filter Category!=NotAutomated
 
       - name: RUN TEST with dedicated collections
-        uses: kohlerdominik/docker-run-action@v1
+        uses: kohlerdominik/docker-run-action@v1.0.2
         with:
           image: squidex/build
           environment: |
@@ -153,7 +153,7 @@ jobs:
        
       - name: Dump docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@v2.2.1
         with:
          images: 'squidex-tmp,squidex/resizer,squidex/caddy-proxy-path'
          tail: '100'
@@ -174,10 +174,10 @@ jobs:
           echo "BUILD_NUMBER=$(($BUILD_NUMBER + 5967))" >> $GITHUB_ENV
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: Get Image From Cache
         if: github.event_name != 'pull_request'
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: squidex-tmp.tar.gz
           key: squidex-dev-image-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: BUILD
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.2.0
         with:
           push: false
           load: true
@@ -44,7 +44,7 @@ jobs:
         run: docker save squidex-tmp | gzip > squidex-tmp.tar.gz
 
       - name: Save Image to Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: squidex-tmp.tar.gz
           key: squidex-release-image-${{ github.sha }}
@@ -59,13 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Get Image From Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: squidex-tmp.tar.gz
           key: squidex-release-image-${{ github.sha }}
@@ -74,17 +74,17 @@ jobs:
         run: docker load < squidex-tmp.tar.gz
 
       - name: Replace Image Name1
-        uses: mikefarah/yq@v4.9.1
+        uses: mikefarah/yq@v4.28.2
         with:
           cmd: yq e '.services.squidex1.image = "squidex-tmp"' -i backend/tests/docker-compose.yml
 
       - name: Replace Image Name2
-        uses: mikefarah/yq@v4.9.1
+        uses: mikefarah/yq@v4.28.2
         with:
           cmd: yq e '.services.squidex2.image = "squidex-tmp"' -i backend/tests/docker-compose.yml
 
       - name: Replace Image Name3
-        uses: mikefarah/yq@v4.9.1
+        uses: mikefarah/yq@v4.28.2
         with:
           cmd: yq e '.services.squidex3.image = "squidex-tmp"' -i backend/tests/docker-compose.yml
 
@@ -93,7 +93,7 @@ jobs:
         working-directory: backend/tests
 
       - name: RUN TEST
-        uses: kohlerdominik/docker-run-action@v1
+        uses: kohlerdominik/docker-run-action@v1.0.2
         with:
           image: squidex/build
           environment: |
@@ -107,7 +107,7 @@ jobs:
           run: dotnet test /src/backend/tools/TestSuite/TestSuite.ApiTests/TestSuite.ApiTests.csproj --filter Category!=NotAutomated
 
       - name: RUN TEST on path
-        uses: kohlerdominik/docker-run-action@v1
+        uses: kohlerdominik/docker-run-action@v1.0.2
         with:
           image: squidex/build
           environment: |
@@ -121,7 +121,7 @@ jobs:
           run: dotnet test /src/backend/tools/TestSuite/TestSuite.ApiTests/TestSuite.ApiTests.csproj --filter Category!=NotAutomated
 
       - name: RUN TEST with dedicated collections
-        uses: kohlerdominik/docker-run-action@v1
+        uses: kohlerdominik/docker-run-action@v1.0.2
         with:
           image: squidex/build
           environment: |
@@ -136,7 +136,7 @@ jobs:
        
       - name: Dump docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@v2.2.1
         with:
          images: 'squidex-tmp,squidex/resizer,squidex/caddy-proxy-path'
          tail: '100'
@@ -151,17 +151,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Get Major Version
         id: version
-        uses: rishabhgupta/split-by@v1
+        uses: rishabhgupta/split-by@v1.0.1
         with:
           string: "${{ env.GITHUB_REF_SLUG }}"
           split-by: "."
@@ -174,7 +174,7 @@ jobs:
           fi
 
       - name: Get Image From Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: squidex-tmp.tar.gz
           key: squidex-release-image-${{ github.sha }}
@@ -204,13 +204,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2.5.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Get Image From Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: squidex-tmp.tar.gz
           key: squidex-release-image-${{ github.sha }}
@@ -233,13 +233,13 @@ jobs:
 
       - name: Get Changelog Entry
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
+        uses: mindsers/changelog-reader-action@v2.2.0
         with:
           version: ${{ env.GITHUB_REF_SLUG }}
           path: ./CHANGELOG.md
 
       - name: Publish Binaries
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.11.1
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[rlespinasse/github-slug-action](https://github.com/rlespinasse/github-slug-action)** published a new release [v4.3.2](https://github.com/rlespinasse/github-slug-action/releases/tag/v4.3.2) on 2022-10-17T19:25:58Z
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release [v1.11.1](https://github.com/ncipollo/release-action/releases/tag/v1.11.1) on 2022-10-04T16:45:37Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release [v2.1.0](https://github.com/docker/setup-qemu-action/releases/tag/v2.1.0) on 2022-10-12T13:40:23Z
* **[mikefarah/yq](https://github.com/mikefarah/yq)** published a new release [v4.28.2](https://github.com/mikefarah/yq/releases/tag/v4.28.2) on 2022-10-19T00:36:13Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release [v3.2.0](https://github.com/docker/build-push-action/releases/tag/v3.2.0) on 2022-10-12T07:10:45Z
* **[kohlerdominik/docker-run-action](https://github.com/kohlerdominik/docker-run-action)** published a new release [v1.0.2](https://github.com/kohlerdominik/docker-run-action/releases/tag/v1.0.2) on 2021-09-06T15:59:01Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release [v2.2.1](https://github.com/docker/setup-buildx-action/releases/tag/v2.2.1) on 2022-10-18T09:17:35Z
* **[jwalton/gh-docker-logs](https://github.com/jwalton/gh-docker-logs)** published a new release [v2.2.1](https://github.com/jwalton/gh-docker-logs/releases/tag/v2.2.1) on 2022-10-13T16:13:34Z
* **[rishabhgupta/split-by](https://github.com/rishabhgupta/split-by)** published a new release [v1.0.1](https://github.com/rishabhgupta/split-by/releases/tag/v1.0.1) on 2020-05-18T04:01:26Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release [v0.7.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.0) on 2022-10-22T14:34:54Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11) on 2022-10-13T11:18:20Z
* **[mindsers/changelog-reader-action](https://github.com/mindsers/changelog-reader-action)** published a new release [v2.2.0](https://github.com/mindsers/changelog-reader-action/releases/tag/v2.2.0) on 2022-09-01T11:20:01Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release [v2.1.0](https://github.com/docker/login-action/releases/tag/v2.1.0) on 2022-10-12T07:04:14Z
