### PR TITLE
Update permissions on external-callback login

### DIFF
--- a/backend/src/Squidex/Areas/IdentityServer/Controllers/Account/AccountController.cs
+++ b/backend/src/Squidex/Areas/IdentityServer/Controllers/Account/AccountController.cs
@@ -241,19 +241,14 @@ public sealed class AccountController : IdentityServerController
         {
             user = await userService.FindByLoginAsync(login.LoginProvider, login.ProviderKey, HttpContext.RequestAborted);
 
-            if (user != null)
+            if (user != null && identityOptions.OidcOverridePermissionsWithCustomClaimsOnLogin)
             {
-                var squidexClaimsFromLoginPrincipal = login.Principal.Claims.GetSquidexClaims();
-
-                if (user.Claims.GetSquidexClaims().Equals(squidexClaimsFromLoginPrincipal))
+                var values = new UserValues
                 {
-                    var values = new UserValues
-                    {
-                        CustomClaims = squidexClaimsFromLoginPrincipal.ToList()
-                    };
+                    CustomClaims = login.Principal.Claims.GetSquidexClaims().ToList()
+                };
 
-                    user = await userService.UpdateAsync(user.Id, values, false, HttpContext.RequestAborted);
-                }
+                user = await userService.UpdateAsync(user.Id, values, false, HttpContext.RequestAborted);
             }
         }
         else

--- a/backend/src/Squidex/Areas/IdentityServer/Controllers/Account/AccountController.cs
+++ b/backend/src/Squidex/Areas/IdentityServer/Controllers/Account/AccountController.cs
@@ -240,6 +240,21 @@ public sealed class AccountController : IdentityServerController
         if (isLoggedIn)
         {
             user = await userService.FindByLoginAsync(login.LoginProvider, login.ProviderKey, HttpContext.RequestAborted);
+
+            if (user != null)
+            {
+                var squidexClaimsFromLoginPrincipal = login.Principal.Claims.GetSquidexClaims();
+
+                if (user.Claims.GetSquidexClaims().Equals(squidexClaimsFromLoginPrincipal))
+                {
+                    var values = new UserValues
+                    {
+                        CustomClaims = squidexClaimsFromLoginPrincipal.ToList()
+                    };
+
+                    user = await userService.UpdateAsync(user.Id, values, false, HttpContext.RequestAborted);
+                }
+            }
         }
         else
         {

--- a/backend/src/Squidex/Config/MyIdentityOptions.cs
+++ b/backend/src/Squidex/Config/MyIdentityOptions.cs
@@ -59,6 +59,8 @@ public sealed class MyIdentityOptions
 
     public bool OidcGetClaimsFromUserInfoEndpoint { get; set; }
 
+    public bool OidcOverridePermissionsWithCustomClaimsOnLogin { get; set; }
+
     public bool AdminRecreate { get; set; }
 
     public bool AllowPasswordAuth { get; set; }

--- a/backend/src/Squidex/appsettings.json
+++ b/backend/src/Squidex/appsettings.json
@@ -596,6 +596,7 @@
         ],
         "oidcResponseType": "id_token", // or "code"
         "oidcGetClaimsFromUserInfoEndpoint": false,
+        "oidcOverridePermissionsWithCustomClaimsOnLogin": false,
         "oidcOnSignoutRedirectUrl": "",
 
         // Lock new users automatically, the administrator must unlock them.


### PR DESCRIPTION
- Previously users that already existed would not have their permissions updated in Squidex

Hello, this has not been tested! Just wanted to know if this makes sense or not? And if it does and works...well feel free to merge!

This is in relation to: https://support.squidex.io/t/openiddict-change-permissions-claims-for-existing-users/4295

Is there test coverage for this class? If so I could not find it, would have preferred to have unit tests covering the scenarios so I could know for sure `Equals` definitely works for Claims as I hope! Assume unit testing around things like `SignInManager` can get a bit complicated?