### PR TITLE
web.config now points at net7.0 folder

### DIFF
--- a/backend/src/Squidex/web.config
+++ b/backend/src/Squidex/web.config
@@ -5,6 +5,6 @@
 			<remove name="aspNetCore" />
 			<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
 		</handlers>
-		<aspNetCore processPath="dotnet" arguments=".\bin\Debug\net6.0\Squidex.dll" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="inprocess" />
+		<aspNetCore processPath="dotnet" arguments=".\bin\Debug\net7.0\Squidex.dll" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="inprocess" />
 	</system.webServer>
 </configuration>


### PR DESCRIPTION
I do not have the net6.0 folder when building locally as most (everything?) is targeting 7.0 now.

Using Github's editor that for some reason has decided the end of the file needs to change and I don't know how to unstage that bit(!) so it's up to you if that's OK or not!