### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.4.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,19 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.4.0
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v4.3.2
+        uses: rlespinasse/github-slug-action@v4.4.1
 
       - name: Prepare - Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
 
       - name: Prepare - Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v2.5.0
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v4.0.0
         with:
           load: true
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.4.0
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v4.3.2
+        uses: rlespinasse/github-slug-action@v4.4.1
 
       - name: Prepare - Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
 
       - name: Prepare - Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v2.5.0
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v4.0.0
         with:
           load: true
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
@@ -91,7 +91,7 @@ jobs:
 
       - name: Publish - Get Major Version
         id: version
-        uses: rishabhgupta/split-by@v1
+        uses: rishabhgupta/split-by@v1.0.1
         with:
           string: "${{ env.GITHUB_REF_SLUG }}"
           split-by: "."
@@ -140,13 +140,13 @@ jobs:
 
       - name: Release - Get Changelog Entry
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
+        uses: mindsers/changelog-reader-action@v2.2.2
         with:
           version: ${{ env.GITHUB_REF_SLUG }}
           path: ./CHANGELOG.md
 
       - name: Release - Publish Binaries
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.12.0
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[mindsers/changelog-reader-action](https://github.com/mindsers/changelog-reader-action)** published a new release **[v2.2.2](https://github.com/mindsers/changelog-reader-action/releases/tag/v2.2.2)** on 2022-11-23T14:25:23Z
* **[rishabhgupta/split-by](https://github.com/rishabhgupta/split-by)** published a new release **[v1.0.1](https://github.com/rishabhgupta/split-by/releases/tag/v1.0.1)** on 2020-05-18T04:01:26Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.5.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.5.0)** on 2023-03-10T09:47:20Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.4.0](https://github.com/actions/checkout/releases/tag/v3.4.0)** on 2023-03-15T19:47:24Z
* **[rlespinasse/github-slug-action](https://github.com/rlespinasse/github-slug-action)** published a new release **[v4.4.1](https://github.com/rlespinasse/github-slug-action/releases/tag/v4.4.1)** on 2023-02-20T11:00:14Z
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release **[v1.12.0](https://github.com/ncipollo/release-action/releases/tag/v1.12.0)** on 2022-12-11T20:21:59Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.0.0](https://github.com/docker/build-push-action/releases/tag/v4.0.0)** on 2023-01-30T18:26:38Z
