### PR TITLE
Closing apostrophe in PolymorphicConverter exception message

### DIFF
--- a/backend/src/Squidex.Infrastructure/Json/System/PolymorphicConverter.cs
+++ b/backend/src/Squidex.Infrastructure/Json/System/PolymorphicConverter.cs
@@ -65,7 +65,7 @@ public sealed class PolymorphicConverter<T> : JsonConverter<T> where T : class
             }
         }
 
-        ThrowHelper.JsonException($"Object has no discriminator '{discriminatorName}.");
+        ThrowHelper.JsonException($"Object has no discriminator '{discriminatorName}'.");
         return default!;
     }
 


### PR DESCRIPTION
- Was showing in logs as "Object has no discriminator '$type."