### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/setup-qemu-action@v2.2.0
 
       - name: Prepare - Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.9.1
+        uses: docker/setup-buildx-action@v2.10.0
 
       - name: Build - BUILD
         uses: docker/build-push-action@v4.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-qemu-action@v2.2.0
 
       - name: Prepare - Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.9.1
+        uses: docker/setup-buildx-action@v2.10.0
 
       - name: Build - BUILD
         uses: docker/build-push-action@v4.1.1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.10.0)** on 2023-08-28T07:09:22Z
