### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,13 +22,13 @@ jobs:
         uses: rlespinasse/github-slug-action@v4.4.1
 
       - name: Prepare - Set up QEMU
-        uses: docker/setup-qemu-action@v2.2.0
+        uses: docker/setup-qemu-action@v3.0.0
 
       - name: Prepare - Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.10.0
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v4.2.1
+        uses: docker/build-push-action@v5.0.0
         with:
           load: true
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
@@ -103,7 +103,7 @@ jobs:
 
       - name: Publish - Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
         uses: rlespinasse/github-slug-action@v4.4.1
 
       - name: Prepare - Set up QEMU
-        uses: docker/setup-qemu-action@v2.2.0
+        uses: docker/setup-qemu-action@v3.0.0
 
       - name: Prepare - Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.10.0
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v4.2.1
+        uses: docker/build-push-action@v5.0.0
         with:
           load: true
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
@@ -104,7 +104,7 @@ jobs:
           fi
 
       - name: Publish - Login to Docker Hub
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.0.0](https://github.com/docker/build-push-action/releases/tag/v5.0.0)** on 2023-09-12T07:46:14Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0)** on 2023-09-12T08:05:57Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0)** on 2023-09-12T08:03:47Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.0.0](https://github.com/docker/login-action/releases/tag/v3.0.0)** on 2023-09-12T07:51:46Z
