### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.0
 
       - name: Prepare - Inject short Variables
         uses: rlespinasse/github-slug-action@v4.4.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.0
 
       - name: Prepare - Inject short Variables
         uses: rlespinasse/github-slug-action@v4.4.1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
