### PR TITLE
Replacing deprecated Confluent packages in Squidex.Extensions

### DIFF
--- a/backend/extensions/Squidex.Extensions/Squidex.Extensions.csproj
+++ b/backend/extensions/Squidex.Extensions/Squidex.Extensions.csproj
@@ -13,11 +13,9 @@
     <PackageReference Include="Algolia.Search" Version="6.14.0" />
 	<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />
 	<PackageReference Include="Azure.Search.Documents" Version="11.4.0" />
-	<PackageReference Include="Confluent.Apache.Avro" Version="1.7.7.7" />
-	<PackageReference Include="Confluent.Kafka" Version="2.1.1" />
-	<PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.3.0" />
+	<PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.3.0" />
 	<PackageReference Include="CoreTweet" Version="1.0.0.483" />
-	<PackageReference Include="Elasticsearch.Net" Version="7.17.5" /> 
+	<PackageReference Include="Elasticsearch.Net" Version="7.17.5" />
 	<PackageReference Include="Google.Cloud.Diagnostics.Common" Version="4.4.0" />
 	<PackageReference Include="Google.Cloud.Logging.V2" Version="3.6.0" />
 	<PackageReference Include="Meziantou.Analyzer" Version="2.0.62">


### PR DESCRIPTION
- Confluent.Apache.Avro has a dependency on log4net 2.0.8 that has been flagged as having a critical vulnerability (CVE-2018-1285)
- This also means Confluent.Kafka (now a transitive dependency) has been implicitly upgraded to 2.3.0

Note that this change is untested by myself (it builds!), but hopefully this PR at least raises awareness of the use of deprecated dependencies:
- https://www.nuget.org/packages/Confluent.Apache.Avro
- https://www.nuget.org/packages/Confluent.SchemaRegistry.Serdes