### PR TITLE
Add option to run as nonroot

### DIFF
--- a/helm/squidex/templates/deployment.yaml
+++ b/helm/squidex/templates/deployment.yaml
@@ -23,10 +23,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.runAsNonRoot }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.runAsNonRoot }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/helm/squidex/values.yaml
+++ b/helm/squidex/values.yaml
@@ -46,6 +46,35 @@ affinity: { }
 ## @skip clusterSuffix
 clusterSuffix: cluster.local
 
+## @param runAsNonRoot
+runAsNonRoot: false
+
+## @param podSecurityContext - object - optional
+## You can modify the security context used to run PODS in the cluster
+## For information regarding which settings are required per policy see: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+## An example that follows the Restricted profile is described below:
+#
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+  runAsNonRoot: true
+  runAsUser: 10000
+  runAsGroup: 10000
+  fsGroup: 10000
+
+## @param containerSecurityContext - object - optional
+## You can modify the security context used to run CONTAINERS in the cluster
+## For information regarding which settings are required per policy see: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+## An example that follows the Restricted profile is described below:
+#
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
+
 ## @skip auth
 auth:
   ## 
@@ -165,7 +194,7 @@ env:
 
   ## @param env.LOGGING__APPLICATIONINSIGHTS__ENABLED Enable monitoring via application insights.
   ##
-  LOGGING__APPLICATIONINSIGHTS__ENABLED: falsen
+  LOGGING__APPLICATIONINSIGHTS__ENABLED: false
   ## @param env.LOGGING__APPLICATIONINSIGHTS__CONNECTIONSTRING The connection string to application insights.
   ##
   LOGGING__APPLICATIONINSIGHTS__CONNECTIONSTRING: null # "instrumentationkey=keyvalue"

--- a/helm/squidex/values.yaml
+++ b/helm/squidex/values.yaml
@@ -47,6 +47,7 @@ affinity: { }
 clusterSuffix: cluster.local
 
 ## @param runAsNonRoot
+## Set to true to run Squidex as nonroot. Defaults to false for backwards compatibility.
 runAsNonRoot: false
 
 ## @param podSecurityContext - object - optional

--- a/helm/squidex7/templates/deployment-worker.yaml
+++ b/helm/squidex7/templates/deployment-worker.yaml
@@ -21,10 +21,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.runAsNonRoot }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.runAsNonRoot }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/helm/squidex7/templates/deployment.yaml
+++ b/helm/squidex7/templates/deployment.yaml
@@ -21,10 +21,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.runAsNonRoot }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.runAsNonRoot }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/helm/squidex7/values.yaml
+++ b/helm/squidex7/values.yaml
@@ -46,6 +46,35 @@ affinity: { }
 ## @skip clusterSuffix
 clusterSuffix: cluster.local
 
+## @param runAsNonRoot
+runAsNonRoot: false
+
+## @param podSecurityContext - object - optional
+## You can modify the security context used to run PODS in the cluster
+## For information regarding which settings are required per policy see: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+## An example that follows the Restricted profile is described below:
+#
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+  runAsNonRoot: true
+  runAsUser: 10000
+  runAsGroup: 10000
+  fsGroup: 10000
+
+## @param containerSecurityContext - object - optional
+## You can modify the security context used to run CONTAINERS in the cluster
+## For information regarding which settings are required per policy see: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+## An example that follows the Restricted profile is described below:
+#
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
+
 ## @skip auth
 auth:
   ## 
@@ -213,7 +242,10 @@ env:
   URLS__BASEURL: https://squidex.local/ # 
 
   ## @param env.URLS__ENFORCEHTTPS Set it to true to redirect the user from http to https permanently
-  URLS__ENFORCEHTTPS: false 
+  URLS__ENFORCEHTTPS: false
+
+  ## @param env.ASPNETCORE_URLS: an override to ensure that kestrel starts on a non-privileged port
+  ASPNETCORE_URLS: http://+:80
 
 ## @section MongoDB parameters
 mongodb-replicaset:

--- a/helm/squidex7/values.yaml
+++ b/helm/squidex7/values.yaml
@@ -47,6 +47,7 @@ affinity: { }
 clusterSuffix: cluster.local
 
 ## @param runAsNonRoot
+## Set to true to run Squidex as nonroot. Defaults to false for backwards compatibility.
 runAsNonRoot: false
 
 ## @param podSecurityContext - object - optional


### PR DESCRIPTION
I would like to be able to run Squidex as nonroot user.

MongoDB is already running as nonroot. I have seen [this](https://github.com/Squidex/squidex/pull/941) previous attempt and would like to propose this change which allows running nonroot without breaking existing functionality.

