### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: 18
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: 18
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: snapshots
           path: tools/e2e/snapshots/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: 18
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.0](https://github.com/actions/setup-node/releases/tag/v4.0.0)** on 2023-10-23T14:55:24Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.3](https://github.com/actions/upload-artifact/releases/tag/v3.1.3)** on 2023-09-06T19:16:46Z
