### PR TITLE
Set secure policy on antiforgery cookie to always

### DIFF
--- a/backend/src/Squidex/Areas/IdentityServer/Config/IdentityServerServices.cs
+++ b/backend/src/Squidex/Areas/IdentityServer/Config/IdentityServerServices.cs
@@ -126,6 +126,8 @@ public static class IdentityServerServices
             var identityOptions = c.GetRequiredService<IOptions<MyIdentityOptions>>().Value;
 
             options.SuppressXFrameOptionsHeader = identityOptions.SuppressXFrameOptionsHeader;
+
+            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
         });
 
         services.Configure<OpenIddictServerOptions>((c, options) =>

--- a/backend/src/Squidex/Areas/IdentityServer/Config/IdentityServerServices.cs
+++ b/backend/src/Squidex/Areas/IdentityServer/Config/IdentityServerServices.cs
@@ -18,7 +18,6 @@ using Squidex.Config;
 using Squidex.Domain.Users;
 using Squidex.Domain.Users.InMemory;
 using Squidex.Hosting;
-using Squidex.Hosting.Web;
 using Squidex.Web;
 using Squidex.Web.Pipeline;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -29,7 +28,7 @@ namespace Squidex.Areas.IdentityServer.Config;
 
 public static class IdentityServerServices
 {
-    public static void AddSquidexIdentityServer(this IServiceCollection services, IConfiguration config)
+    public static void AddSquidexIdentityServer(this IServiceCollection services)
     {
         services.Configure<KeyManagementOptions>((c, options) =>
         {
@@ -129,9 +128,9 @@ public static class IdentityServerServices
             options.SuppressXFrameOptionsHeader = identityOptions.SuppressXFrameOptionsHeader;
 
             // Set antiforgery cookie secure policy to always for https
-            var urlsOptions = config.GetSection("urls").Get<UrlOptions>() ?? new ();
+            var baseUrl = c.GetRequiredService<IUrlGenerator>().BuildUrl();
 
-            if (urlsOptions.BaseUrl?.StartsWith("https://", StringComparison.OrdinalIgnoreCase) == true)
+            if (baseUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             {
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
             }

--- a/backend/src/Squidex/Areas/IdentityServer/Config/IdentityServerServices.cs
+++ b/backend/src/Squidex/Areas/IdentityServer/Config/IdentityServerServices.cs
@@ -18,6 +18,7 @@ using Squidex.Config;
 using Squidex.Domain.Users;
 using Squidex.Domain.Users.InMemory;
 using Squidex.Hosting;
+using Squidex.Hosting.Web;
 using Squidex.Web;
 using Squidex.Web.Pipeline;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -28,7 +29,7 @@ namespace Squidex.Areas.IdentityServer.Config;
 
 public static class IdentityServerServices
 {
-    public static void AddSquidexIdentityServer(this IServiceCollection services)
+    public static void AddSquidexIdentityServer(this IServiceCollection services, IConfiguration config)
     {
         services.Configure<KeyManagementOptions>((c, options) =>
         {
@@ -127,7 +128,13 @@ public static class IdentityServerServices
 
             options.SuppressXFrameOptionsHeader = identityOptions.SuppressXFrameOptionsHeader;
 
-            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            // Set antiforgery cookie secure policy to always for https
+            var urlsOptions = config.GetSection("urls").Get<UrlOptions>() ?? new ();
+
+            if (urlsOptions.BaseUrl?.StartsWith("https://", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            }
         });
 
         services.Configure<OpenIddictServerOptions>((c, options) =>

--- a/backend/src/Squidex/Startup.cs
+++ b/backend/src/Squidex/Startup.cs
@@ -38,7 +38,7 @@ public sealed class Startup
         // They must be called in this order.
         services.AddSquidexMvcWithPlugins(config);
         services.AddSquidexIdentity(config);
-        services.AddSquidexIdentityServer();
+        services.AddSquidexIdentityServer(config);
         services.AddSquidexAuthentication(config);
 
         services.AddSquidexApps(config);

--- a/backend/src/Squidex/Startup.cs
+++ b/backend/src/Squidex/Startup.cs
@@ -38,7 +38,7 @@ public sealed class Startup
         // They must be called in this order.
         services.AddSquidexMvcWithPlugins(config);
         services.AddSquidexIdentity(config);
-        services.AddSquidexIdentityServer(config);
+        services.AddSquidexIdentityServer();
         services.AddSquidexAuthentication(config);
 
         services.AddSquidexApps(config);


### PR DESCRIPTION
One-liner to set the cookie secure policy to always on the antiforgery cookie.