### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.1.0
+        uses: actions/upload-artifact@v4.2.0
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.1.0
+        uses: actions/upload-artifact@v4.2.0
         with:
           name: snapshots
           path: tools/e2e/snapshots/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.1.0
+        uses: actions/upload-artifact@v4.2.0
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.2.0](https://github.com/actions/upload-artifact/releases/tag/v4.2.0)** on 2024-01-18T20:12:17Z
