### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v4.4.1
+        uses: rlespinasse/github-slug-action@v4.5.0
 
       - name: Prepare - Setup QEMU
         uses: docker/setup-qemu-action@v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v4.4.1
+        uses: rlespinasse/github-slug-action@v4.5.0
 
       - name: Prepare - Setup QEMU
         uses: docker/setup-qemu-action@v3.0.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[rlespinasse/github-slug-action](https://github.com/rlespinasse/github-slug-action)** published a new release **[v4.5.0](https://github.com/rlespinasse/github-slug-action/releases/tag/v4.5.0)** on 2024-04-30T20:32:29Z
