### PR TITLE
Build for ARM platforms for self-hosted Squidex instances

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           tags: squidex-local
 
       - name: Test - Start Compose


### PR DESCRIPTION
I've attempted to run Squidex on an ARM k8s instance, and I'm encountering a `exec /usr/bin/dotnet: exec format error` issue which is related to the container being built for amd64 and not arm