### PR TITLE
Dev workflow: add building for ARM platforms

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -39,6 +39,7 @@ jobs:
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           tags: squidex-local
 
       - name: Test - Start Compose

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -39,7 +39,6 @@ jobs:
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
           tags: squidex-local
 
       - name: Test - Start Compose
@@ -135,6 +134,15 @@ jobs:
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
           echo "BUILD_NUMBER=$(($BUILD_NUMBER + 6000))" >> $GITHUB_ENV
+
+      - name: Publish - Build for Multi-Platforms
+        uses: docker/build-push-action@v5.3.0
+        with:
+          build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          tags: squidex-local
 
       - name: Publish - Login to Docker Hub
         if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
           tags: squidex-local
 
       - name: Test - Start Compose
@@ -116,6 +115,15 @@ jobs:
         if: always()
         run: docker-compose down
         working-directory: tools/TestSuite
+
+      - name: Publish - Build for Multi-Platforms
+        uses: docker/build-push-action@v5.3.0
+        with:
+          build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          tags: squidex-local
 
       - name: Publish - Get Major Version
         id: version

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1, Build Backend
 #
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as backend
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 as backend
 
 ARG SQUIDEX__BUILD__VERSION=7.0.0
 


### PR DESCRIPTION
Related to https://github.com/Squidex/squidex/pull/1093

I missed the change for the dev workflow, so hopefully builds in https://hub.docker.com/r/squidex/squidex/tags will also be arm64 too