### PR TITLE
CI: Update Release Workflow to Build & Push for ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,15 +121,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-      - name: Publish - Build for Multi-Platforms
-        uses: docker/build-push-action@v5.4.0
-        with:
-          build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-          tags: squidex-local
-
       - name: Publish - Get Major Version
         id: version
         uses: rishabhgupta/split-by@v1.0.1
@@ -150,16 +141,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Publish - Rename Tags
-        run: |
-          docker tag squidex-local squidex/squidex:latest
-          docker tag squidex-local squidex/squidex:${{ env.GITHUB_REF_SLUG }}
-          docker tag squidex-local squidex/squidex:${{ steps.version.outputs._0 }}
-    
-      - name: Publish - Push Tags
-        run: |
-          docker push squidex/squidex:${{ env.GITHUB_REF_SLUG }}
-          docker push squidex/squidex:${{ steps.version.outputs._0 }}
+      - name: Publish - Build & Push for Multi-Platforms
+        uses: docker/build-push-action@v5.3.0
+        with:
+          build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          tags: squidex/squidex:${{ env.GITHUB_REF_SLUG }},squidex/squidex:${{ steps.version.outputs._0 }}
+          push: {{ github.event_name != 'pull_request' }}
     
       - name: Publish - Push Tags Latest
         if: env.STABLE_VERSION == 'true'


### PR DESCRIPTION
Sorry about the delay

I joined the pushing of tags into the build-push-action, and left the STABLE_VERSION on its own step. (Replicating the changes made in https://github.com/Squidex/squidex/pull/1100)

Let me know if any concerns :)