### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,10 +22,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v4.5.0
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.1.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.3.0
+        uses: docker/setup-buildx-action@v3.4.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.0.2
@@ -33,7 +33,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v5.4.0
+        uses: docker/build-push-action@v6.3.0
         with:
           load: true
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
@@ -103,7 +103,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/
@@ -111,7 +111,7 @@ jobs:
        
       - name: Test - Upload Screenshots
         if: failure()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.3.4
         with:
           path: |
             tools/TestSuite/TestSuite.ApiTests/bin/Debug/net8.0/screenshots/
@@ -149,7 +149,7 @@ jobs:
 
       - name: Publish - Build & Push for Multi-Platforms
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5.4.0
+        uses: docker/build-push-action@v6.3.0
         with:
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
           cache-from: type=gha

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -12,10 +12,10 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.1.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.3.0
+        uses: docker/setup-buildx-action@v3.4.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.0.2
@@ -23,7 +23,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v5.4.0
+        uses: docker/build-push-action@v6.3.0
         with:
           load: true
           cache-from: type=gha
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: snapshots
           path: tools/e2e/snapshots/


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.4](https://github.com/actions/upload-artifact/releases/tag/v4.3.4)** on 2024-07-05T15:15:04Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.1.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.1.0)** on 2024-07-03T11:26:55Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.4.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.4.0)** on 2024-07-04T07:35:04Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.3.0](https://github.com/docker/build-push-action/releases/tag/v6.3.0)** on 2024-07-03T07:47:10Z
