### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,10 +22,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v4.5.0
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.1.0
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.4.0
+        uses: docker/setup-buildx-action@v3.5.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.0.3
@@ -33,7 +33,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           load: true
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
@@ -142,14 +142,14 @@ jobs:
 
       - name: Publish - Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.2.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Publish - Build & Push for Multi-Platforms
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
           cache-from: type=gha

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -12,10 +12,10 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.1.0
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.4.0
+        uses: docker/setup-buildx-action@v3.5.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.0.3
@@ -23,7 +23,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           load: true
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v4.5.0
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.1.0
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.4.0
+        uses: docker/setup-buildx-action@v3.5.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.0.3
@@ -28,7 +28,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           load: true
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
@@ -136,13 +136,13 @@ jobs:
           fi
 
       - name: Publish - Login to Docker Hub
-        uses: docker/login-action@v3.2.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Publish - Build & Push for Multi-Platforms
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
           cache-from: type=gha


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.5.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.5.0)** on 2024-07-22T09:50:22Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.5.0](https://github.com/docker/build-push-action/releases/tag/v6.5.0)** on 2024-07-22T09:58:55Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.2.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.2.0)** on 2024-07-22T09:28:59Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.3.0](https://github.com/docker/login-action/releases/tag/v3.3.0)** on 2024-07-22T09:07:15Z
