### PR TITLE
fix login screen ui separators showing incorreclty

### DIFF
--- a/backend/src/Squidex/Areas/IdentityServer/Views/Account/Login.cshtml
+++ b/backend/src/Squidex/Areas/IdentityServer/Views/Account/Login.cshtml
@@ -49,9 +49,12 @@
 
     @if (Model.HasPasswordAuth)
     {
-        <div class="profile-separator">
-            <div class="profile-separator-text">@T.Get("users.login.separator")</div>
-        </div>
+        @if (Model.HasExternalLogin && Model.IsLogin)
+        {
+            <div class="profile-separator">
+                <div class="profile-separator-text">@T.Get("users.login.separator")</div>
+            </div>
+        }
 
         if (Model.IsLogin)
         {
@@ -84,9 +87,12 @@
 
     @if (Model.HasCustomAuth && Model.IsLogin)
     {
-        <div class="profile-separator">
-            <div class="profile-separator-text">@T.Get("users.login.separator")</div>
-        </div>
+        @if ((Model.HasExternalLogin || Model.HasPasswordAuth) && Model.IsLogin)
+        {
+            <div class="profile-separator">
+                <div class="profile-separator-text">@T.Get("users.login.separator")</div>
+            </div>
+        }
 
         @if (Model.RequestType == RequestType.LoginCustom)
         {


### PR DESCRIPTION
Fixes a bug where the ui separator on the login screen isn't shown correclty depending on what login methods are enabled.
https://support.squidex.io/t/separator-on-login-screen-is-showing-when-it-shouldnt/5607