### PR TITLE
Added nodePort as an attribute of the Helm chart.

### DIFF
--- a/helm/squidex/templates/service.yaml
+++ b/helm/squidex/templates/service.yaml
@@ -11,5 +11,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if and (eq (lower .Values.service.type) "nodeport") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "squidex.selectors" . | indent 4 }}

--- a/helm/squidex/values.yaml
+++ b/helm/squidex/values.yaml
@@ -9,6 +9,9 @@ service:
   ## @param service.port Kubernetes Service port
   ##
   port: 80
+  ## @param service.port Kubernetes Service port
+  ##
+  nodePort: null
 deployment:
   ## @param deployment.replicaCount Number of instances.
   ##


### PR DESCRIPTION
This option lets you specify the desired port when you need the service of type nodePort. The parameter is optional.