### PR TITLE
Open links in new tab by holding meta key

### DIFF
--- a/frontend/src/app/framework/angular/tab-router-link.directive.ts
+++ b/frontend/src/app/framework/angular/tab-router-link.directive.ts
@@ -30,7 +30,7 @@ export class TabRouterlinkDirective {
             relativeTo: this.route,
         });
 
-        if (event.ctrlKey) {
+        if (event.ctrlKey || event.metaKey) {
             const url = this.router.serializeUrl(urlTree);
 
             window.open(url, '_blank');


### PR DESCRIPTION
On MacOS `Ctrl + click` opens context menu, so it would be nice also to add `Cmd + click` hotkey
https://support.squidex.io/t/implemented-improvement-for-mass-content-editing/5410/3