### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
 
       - name: Prepare - Inject short Variables
         uses: rlespinasse/github-slug-action@v4.5.0
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.7.1
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
 

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup QEMU
         uses: docker/setup-qemu-action@v3.2.0
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.7.1
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
 
       - name: Prepare - Inject short Variables
         uses: rlespinasse/github-slug-action@v4.5.0
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.7.1
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)** on 2024-10-24T13:51:16Z
