### PR TITLE
Enabled OTel logging and metrics OTLP exporters

### DIFF
--- a/backend/src/Squidex.Infrastructure/ITelemetryConfigurator.cs
+++ b/backend/src/Squidex.Infrastructure/ITelemetryConfigurator.cs
@@ -5,6 +5,7 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 namespace Squidex.Infrastructure;
@@ -12,6 +13,10 @@ namespace Squidex.Infrastructure;
 public interface ITelemetryConfigurator
 {
     void Configure(TracerProviderBuilder builder)
+    {
+    }
+
+    void Configure(MeterProviderBuilder builder)
     {
     }
 }

--- a/backend/src/Squidex/Config/Domain/TelemetryServices.cs
+++ b/backend/src/Squidex/Config/Domain/TelemetryServices.cs
@@ -25,7 +25,7 @@ public static class TelemetryServices
 
         services.AddOpenTelemetry();
 
-        // configure logging
+        // Configure logging
         services.AddLogging(builder =>
         {
             builder.AddOpenTelemetry(options =>
@@ -33,7 +33,7 @@ public static class TelemetryServices
                 options.SetResourceBuilder(resourceBuilder);
                 options.IncludeFormattedMessage = true;
 
-                // add OTLP exporter and bind options directly. Sadly not possible
+                // Add OTLP exporter and bind options directly. Sadly not possible
                 // to do it through ITelemetryConfigurator as it is not possible to
                 // get IServiceProvider here. Later when OpenTelemetry.Sdk.CreateLoggerProviderBuilder()
                 // is available and no longer expermential, we can do it the same way as with tracing and metrics...
@@ -47,7 +47,7 @@ public static class TelemetryServices
             });
         });
 
-        // configure tracing
+        // Configure tracing
         services.AddSingleton(serviceProvider =>
         {
             var builder = Sdk.CreateTracerProviderBuilder();
@@ -74,7 +74,7 @@ public static class TelemetryServices
             return builder.Build()!;
         });
 
-        // configure metrics
+        // Configure metrics
         services.AddSingleton(serviceProvider =>
         {
             var builder = Sdk.CreateMeterProviderBuilder();

--- a/backend/src/Squidex/Config/Domain/TelemetryServices.cs
+++ b/backend/src/Squidex/Config/Domain/TelemetryServices.cs
@@ -6,6 +6,8 @@
 // ==========================================================================
 
 using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Squidex.Infrastructure;
@@ -16,21 +18,42 @@ public static class TelemetryServices
 {
     public static void AddSquidexTelemetry(this IServiceCollection services, IConfiguration config)
     {
+        var serviceName = config.GetValue<string>("logging:name") ?? "Squidex";
+        var resourceBuilder = ResourceBuilder.CreateDefault()
+            .AddService(serviceName, "Squidex",
+                typeof(TelemetryServices).Assembly.GetName().Version!.ToString());
+
         services.AddOpenTelemetry();
 
+        // configure logging
+        services.AddLogging(builder =>
+        {
+            builder.AddOpenTelemetry(options =>
+            {
+                options.SetResourceBuilder(resourceBuilder);
+                options.IncludeFormattedMessage = true;
+
+                // add OTLP exporter and bind options directly. Sadly not possible
+                // to do it through ITelemetryConfigurator as it is not possible to
+                // get IServiceProvider here. Later when OpenTelemetry.Sdk.CreateLoggerProviderBuilder()
+                // is available and no longer expermential, we can do it the same way as with tracing and metrics...
+                if (config.GetValue<bool>("logging:otlp:enabled"))
+                {
+                    options.AddOtlpExporter(options =>
+                    {
+                        config.GetSection("logging:otlp").Bind(options);
+                    });
+                }
+            });
+        });
+
+        // configure tracing
         services.AddSingleton(serviceProvider =>
         {
             var builder = Sdk.CreateTracerProviderBuilder();
 
-            var serviceName = config.GetValue<string>("logging:name") ?? "Squidex";
-
-            builder.SetResourceBuilder(
-                ResourceBuilder.CreateDefault()
-                    .AddService(serviceName, "Squidex",
-                        typeof(TelemetryServices).Assembly.GetName().Version!.ToString()));
-
+            builder.SetResourceBuilder(resourceBuilder);
             builder.AddSource("Squidex");
-
             builder.AddAspNetCoreInstrumentation();
             builder.AddHttpClientInstrumentation();
 
@@ -42,6 +65,24 @@ public static class TelemetryServices
                     new ParentBasedSampler(
                         new TraceIdRatioBasedSampler(sampling)));
             }
+
+            foreach (var configurator in serviceProvider.GetRequiredService<IEnumerable<ITelemetryConfigurator>>())
+            {
+                configurator.Configure(builder);
+            }
+
+            return builder.Build()!;
+        });
+
+        // configure metrics
+        services.AddSingleton(serviceProvider =>
+        {
+            var builder = Sdk.CreateMeterProviderBuilder();
+
+            builder.SetResourceBuilder(resourceBuilder);
+            builder.AddAspNetCoreInstrumentation();
+            builder.AddHttpClientInstrumentation();
+            builder.AddRuntimeInstrumentation();
 
             foreach (var configurator in serviceProvider.GetRequiredService<IEnumerable<ITelemetryConfigurator>>())
             {

--- a/backend/src/Squidex/Squidex.csproj
+++ b/backend/src/Squidex/Squidex.csproj
@@ -63,6 +63,7 @@
     <PackageReference Include="OpenCover" Version="4.7.1221" PrivateAssets="all" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageReference Include="RefactoringEssentials" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="ReportGenerator" Version="5.3.8" PrivateAssets="all" />
     <PackageReference Include="Squidex.Assets.Azure" Version="6.19.0" />


### PR DESCRIPTION
As discussed here: <https://support.squidex.io/t/wider-opentelemetry-support/5718>

Maybe in the future it should be possible (in configuration) to toggle if each of the OTLP exporters are enabled or not. Right now tracing, logging and metric exporter are enabled when `logging:otlp:enabled` is `true`. Even better if we also could configure `endpoint` for each type as in the specs <https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#endpoint-configuration>.