### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           load: true
           cache-from: type=gha
@@ -148,7 +148,7 @@ jobs:
 
       - name: Publish - Build & Push for Multi-Platforms
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
           cache-from: type=gha

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           load: true
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           load: true
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
@@ -142,7 +142,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Publish - Build & Push for Multi-Platforms
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
           cache-from: type=gha


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.10.0](https://github.com/docker/build-push-action/releases/tag/v6.10.0)** on 2024-11-26T10:49:47Z
