### PR TITLE
Changing helm chart to use AppVersion out of the box

### DIFF
--- a/helm/squidex7/README.md
+++ b/helm/squidex7/README.md
@@ -46,16 +46,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
-| Name                      | Description                    | Value             |
-| ------------------------- | ------------------------------ | ----------------- |
-| `service.type`            | Kubernetes Service type        | `ClusterIP`       |
-| `service.port`            | Kubernetes Service port        | `80`              |
-| `deployment.replicaCount` | Number of instances.           | `1`               |
-| `image.repository`        | Squidex image registry         | `squidex/squidex` |
-| `image.tag`               | Squidex image tag              | `7.0.2`           |
-| `image.pullPolicy`        | Squidex image pull policy      | `IfNotPresent`    |
-| `ingress.enabled`         | True to deploy an ingress      | `true`            |
-| `ingress.hostName`        | The host name for the ingress. | `squidex.local`   |
+| Name                      | Description                    | Value                          |
+| ------------------------- | ------------------------------ | ------------------------------ |
+| `service.type`            | Kubernetes Service type        | `ClusterIP`                    |
+| `service.port`            | Kubernetes Service port        | `80`                           |
+| `deployment.replicaCount` | Number of instances.           | `1`                            |
+| `image.repository`        | Squidex image registry         | `squidex/squidex`              |
+| `image.tag`               | Squidex image tag              | null: Uses chart's App Version |
+| `image.pullPolicy`        | Squidex image pull policy      | `IfNotPresent`                 |
+| `ingress.enabled`         | True to deploy an ingress      | `true`                         |
+| `ingress.hostName`        | The host name for the ingress. | `squidex.local`                |
 
 
 ### Squidex parameters

--- a/helm/squidex7/values.yaml
+++ b/helm/squidex7/values.yaml
@@ -27,9 +27,9 @@ image:
   ## @param image.repository Squidex image registry
   ##
   repository: squidex/squidex
-  ## @param image.tag Squidex image tag
+  ## @param image.tag Override Squidex image tag; use chart's AppVersion otherwise
   ##
-  tag: "7.0.2"
+  # tag: "7.0.2"
   ## @param image.pullPolicy Squidex image pull policy
   ##
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This fixes issues where fresh installations must explicitly set and maintain the image tag, explicitly set it null in values, or install an older version of Squidex (currently `7.0.2`) hidden behind an apparently valid AppVersion