### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,10 +22,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v5.0.0
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.3.0
+        uses: docker/setup-qemu-action@v3.4.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@v3.9.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.2.0
@@ -33,7 +33,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         with:
           load: true
           cache-from: type=gha
@@ -152,7 +152,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/
@@ -166,7 +166,7 @@ jobs:
 
       - name: Test - Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.1
         with:
             name: docker-logs
             path: './docker-logs'
@@ -197,7 +197,7 @@ jobs:
 
       - name: Publish - Build & Push for Multi-Platforms
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         with:
           build-args: "SQUIDEX__RUNTIME__VERSION=7.0.0-dev-${{ env.BUILD_NUMBER }}"
           cache-from: type=gha

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -12,10 +12,10 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.3.0
+        uses: docker/setup-qemu-action@v3.4.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@v3.9.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.2.0
@@ -23,7 +23,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         with:
           load: true
           cache-from: type=gha
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: snapshots
           path: tools/e2e/snapshots/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
         uses: rlespinasse/github-slug-action@v5.0.0
 
       - name: Prepare - Setup QEMU
-        uses: docker/setup-qemu-action@v3.3.0
+        uses: docker/setup-qemu-action@v3.4.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@v3.9.0
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.2.0
@@ -28,7 +28,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         with:
           load: true
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
@@ -70,7 +70,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/
@@ -84,7 +84,7 @@ jobs:
 
       - name: Test - Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.1
         with:
             name: docker-logs
             path: './docker-logs'
@@ -120,7 +120,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Publish - Build & Push for Multi-Platforms
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@v6.14.0
         with:
           build-args: "SQUIDEX__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},SQUIDEX__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"
           cache-from: type=gha
@@ -150,7 +150,7 @@ jobs:
           path: ./CHANGELOG.md
 
       - name: Release - Publish Binaries
-        uses: ncipollo/release-action@v1.15.0
+        uses: ncipollo/release-action@v1.16.0
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.9.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.9.0)** on 2025-02-06T13:27:36Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.4.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.4.0)** on 2025-02-06T13:24:22Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)** on 2025-02-21T19:00:26Z
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release **[v1.16.0](https://github.com/ncipollo/release-action/releases/tag/v1.16.0)** on 2025-02-22T16:37:37Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.14.0](https://github.com/docker/build-push-action/releases/tag/v6.14.0)** on 2025-02-19T15:23:54Z
