### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -57,7 +57,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -158,7 +158,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -52,7 +52,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -153,7 +153,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.3.0](https://github.com/actions/setup-dotnet/releases/tag/v4.3.0)** on 2025-01-30T03:20:58Z
