### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -55,7 +55,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -156,7 +156,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -50,7 +50,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 
@@ -151,7 +151,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: 8.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.3.0](https://github.com/actions/setup-dotnet/releases/tag/v4.3.0)** on 2025-01-30T03:20:58Z
