### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v5.0.0
+        uses: rlespinasse/github-slug-action@v5.1.0
 
       - name: Prepare - Setup QEMU
         uses: docker/setup-qemu-action@v3.6.0
@@ -236,7 +236,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v5.0.0
+        uses: rlespinasse/github-slug-action@v5.1.0
 
       - name: Prepare - Setup QEMU
         uses: docker/setup-qemu-action@v3.6.0
@@ -237,7 +237,7 @@ jobs:
           fi
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[rlespinasse/github-slug-action](https://github.com/rlespinasse/github-slug-action)** published a new release **[v5.1.0](https://github.com/rlespinasse/github-slug-action/releases/tag/v5.1.0)** on 2025-03-11T03:17:15Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)** on 2025-03-14T09:53:25Z
