### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
 
@@ -55,12 +55,12 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 18
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: docker-logs
           path: './docker-logs'
@@ -156,12 +156,12 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 18
 
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: docker-logs-${{ matrix.name }}
           path: './docker-logs'
@@ -214,7 +214,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v5.0.0
+        uses: rlespinasse/github-slug-action@v5.1.0
 
       - name: Prepare - Setup QEMU
         uses: docker/setup-qemu-action@v3.6.0
@@ -236,7 +236,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 18
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test - Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: snapshots
           path: tools/e2e/snapshots/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
 
@@ -50,12 +50,12 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 18
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload Playwright Artifacts
         if: always()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: playwright-report
           path: tools/e2e/playwright-report/
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: docker-logs
           path: './docker-logs'
@@ -151,12 +151,12 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Prepare - Setup dotnet
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
 
       - name: Prepare - Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 18
 
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload docker logs
         if: failure()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: docker-logs-${{ matrix.name }}
           path: './docker-logs'
@@ -209,7 +209,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v5.0.0
+        uses: rlespinasse/github-slug-action@v5.1.0
 
       - name: Prepare - Setup QEMU
         uses: docker/setup-qemu-action@v3.6.0
@@ -237,7 +237,7 @@ jobs:
           fi
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.3.1](https://github.com/actions/setup-dotnet/releases/tag/v4.3.1)** on 2025-03-17T02:59:06Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)** on 2025-03-19T17:47:02Z
* **[rlespinasse/github-slug-action](https://github.com/rlespinasse/github-slug-action)** published a new release **[v5.1.0](https://github.com/rlespinasse/github-slug-action/releases/tag/v5.1.0)** on 2025-03-11T03:17:15Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)** on 2025-03-14T09:53:25Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.3.0](https://github.com/actions/setup-node/releases/tag/v4.3.0)** on 2025-03-17T02:44:28Z
