### PR TITLE
Enhance Security: Redact Sensitive Configuration Values in Logs

### DIFF
--- a/backend/src/Squidex/Config/Startup/LogConfigurationHost.cs
+++ b/backend/src/Squidex/Config/Startup/LogConfigurationHost.cs
@@ -5,12 +5,36 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
+using System.Text.RegularExpressions;
 using Squidex.Log;
 
 namespace Squidex.Config.Startup;
 
 public sealed class LogConfigurationHost(IConfiguration configuration, ISemanticLog log) : IHostedService
 {
+    private static readonly Regex[] SensitivePatterns = new[]
+    {
+        // Authentication and API keys
+        new Regex(@"(?i)(secret|token|key|password|credential|auth|api[_-]?key)$"),
+        new Regex(@"(?i)^(aws|azure|google|microsoft|github)[_-]"),
+        new Regex(@"(?i)(jwt|bearer|oauth|saml)"),
+        new Regex(@"(?i)(client|secret|password)$"),
+        
+        // Connection strings and credentials
+        new Regex(@"(?i)(connectionstring|connection)$"),
+        new Regex(@"(?i)(username|password|credential)$"),
+        
+        // Cloud provider specific
+        new Regex(@"(?i)(accesskey|secretkey|privatekey|publickey)$"),
+        new Regex(@"(?i)(projectid|tenantid)$"),
+        
+        // Database specific
+        new Regex(@"(?i)(mongodb|sqlserver|postgres|mysql)://.*"),
+        new Regex(@"(?i)(database|db|server|host|port|user|pass)=")
+    };
+
+    private static readonly string RedactedValue = "*****";
+
     public Task StartAsync(
         CancellationToken cancellationToken)
     {
@@ -20,18 +44,43 @@ public sealed class LogConfigurationHost(IConfiguration configuration, ISemantic
             {
                 var logged = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                var orderedConfigs = configuration.AsEnumerable().Where(kvp => kvp.Value != null).OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase);
+                var orderedConfigs = configuration.AsEnumerable()
+                    .Where(kvp => kvp.Value != null)
+                    .OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase);
 
                 foreach (var (key, val) in orderedConfigs)
                 {
                     if (logged.Add(key))
                     {
-                        c.WriteProperty(key.ToLowerInvariant(), val);
+                        var keyLower = key.ToLowerInvariant();
+                        var value = IsSensitiveKey(keyLower) || IsSensitiveValue(val) ? RedactedValue : val;
+                        
+                        c.WriteProperty(keyLower, value);
                     }
                 }
             }));
 
         return Task.CompletedTask;
+    }
+
+    private static bool IsSensitiveKey(string key)
+    {
+        return SensitivePatterns.Any(pattern => pattern.IsMatch(key));
+    }
+
+    private static bool IsSensitiveValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        // Check for connection strings and URLs with credentials
+        return value.Contains("://") && (
+            value.Contains("@") || // Contains username/password in URL
+            value.Contains(";") || // Contains connection string parameters
+            value.Contains("=")    // Contains key-value pairs
+        );
     }
 
     public Task StopAsync(


### PR DESCRIPTION
## Problem
The current logging implementation exposes sensitive configuration values in plain text, including:
- Authentication secrets (Google, GitHub, Microsoft, OIDC)
- Database credentials and connection strings
- Cloud provider access keys
- API keys and tokens

This poses a security risk as sensitive information could be exposed through log files or monitoring systems.

## Solution
Enhanced the `LogConfigurationHost` to properly identify and redact sensitive configuration values:

1. **Improved Pattern Detection**:
   - Added comprehensive regex patterns for sensitive keys
   - Organized patterns by category (auth, connection strings, cloud providers)
   - Added support for common credential formats

2. **Value Content Analysis**:
   - Added intelligent analysis of configuration values
   - Detection of connection strings and URLs with embedded credentials
   - Pattern matching for common sensitive data formats

3. **Categories of Protected Data**:
   - Authentication & API keys
   - Connection strings & credentials
   - Cloud provider specific keys
   - Database connection details

## Implementation Details
- Added new regex patterns to catch more sensitive data types
- Implemented `IsSensitiveValue()` method for content-based analysis
- Maintains compatibility with both appsettings.json and environment variables
- Uses "*****" for redacted values consistently


## Testing
- Verified redaction of sensitive values in logs
- Tested with various configuration formats:
  - Environment variables
  - Connection strings
  - API keys
  - Cloud provider credentials

## Security Impact
- Prevents accidental exposure of secrets in logs
- Improves compliance with security best practices
- Reduces risk of credential leakage

## Breaking Changes
None. This is a non-breaking enhancement to existing logging functionality.

## Related Issues
- https://support.squidex.io/t/secrets-are-exposed-in-logs-at-information-level/5861

## Screenshots
```shell
{
  "logLevel": "Information",
  "message": "Application started",
  "environment": {
    "applicationname": "Squidex",
    "apps:deletepermanent": "False",
    "assets:allowavifauto": "False",
    "assets:allowwebpauto": "True",
    "assets:cancache": "True",
    "assets:defaultpagesize": "200",
    "assets:deletepermanent": "False",
    "assets:deleterecursive": "True",
    "assets:folderperapp": "False",
    "assets:maxresults": "200",
    "assets:maxsize": "5242880",
    "assets:resizerurl": "",
    "assets:timeoutfind": "00:00:01",
    "assets:timeoutquery": "00:00:05",
    "assetstore:amazons3:accesskey": "*****",
    "assetstore:amazons3:bucket": "squidex-test",
    "assetstore:amazons3:bucketfolder": "squidex-assets",
    "assetstore:amazons3:disablepayloadsigning": "False",
    "assetstore:amazons3:forcepathstyle": "False",
    "assetstore:amazons3:regionname": "eu-central-1",
    "assetstore:amazons3:secretkey": "*****",
    "assetstore:amazons3:serviceurl": "",
    "assetstore:azureblob:connectionstring": "*****",
    "assetstore:azureblob:containername": "squidex-assets",
    "assetstore:exposesourceurl": "False",
    "assetstore:folder:path": "Assets",
    "assetstore:ftp:password": "*****",
    "assetstore:ftp:path": "Assets",
    "assetstore:ftp:serverhost": "",
    "assetstore:ftp:serverport": "21",
    "assetstore:ftp:username": "*****",
    "assetstore:googlecloud:bucket": "squidex-assets",
    "assetstore:mongodb:bucket": "fs",
    "assetstore:mongodb:configuration": "mongodb://localhost",
    "assetstore:mongodb:database": "SquidexAssets",
    "assetstore:type": "Folder",
    "caching:apps:cacheduration": "00:00:00",
    "caching:domainobjects:cacheduration": "00:10:00",
    "caching:maxsurrogatekeyssize": "0",
 ```