### PR TITLE
Add fields parameter to FindContentAsync methods across repositories

### DIFF
--- a/backend/src/Squidex.Data.EntityFramework/Domain/Apps/Entities/Contents/EFContentRepository.cs
+++ b/backend/src/Squidex.Data.EntityFramework/Domain/Apps/Entities/Contents/EFContentRepository.cs
@@ -27,8 +27,7 @@ public sealed partial class EFContentRepository<TContext, TContentContext>(
 {
     private readonly DynamicTables<TContext, TContentContext> dynamicTables = new DynamicTables<TContext, TContentContext>(dbContextFactory, dbContentContextFactory);
 
-    public async Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope,
-        IEnumerable<string>? fields, // TODO: Not used yet
+    public async Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope, IEnumerable<string>? fields, // TODO: Not used yet
         CancellationToken ct = default)
     {
         using (Telemetry.Activities.StartActivity("EFContentRepository/FindContentAsync"))

--- a/backend/src/Squidex.Data.EntityFramework/Domain/Apps/Entities/Contents/EFContentRepository.cs
+++ b/backend/src/Squidex.Data.EntityFramework/Domain/Apps/Entities/Contents/EFContentRepository.cs
@@ -28,6 +28,7 @@ public sealed partial class EFContentRepository<TContext, TContentContext>(
     private readonly DynamicTables<TContext, TContentContext> dynamicTables = new DynamicTables<TContext, TContentContext>(dbContextFactory, dbContentContextFactory);
 
     public async Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope,
+        IEnumerable<string>? fields, // TODO: Not used yet
         CancellationToken ct = default)
     {
         using (Telemetry.Activities.StartActivity("EFContentRepository/FindContentAsync"))

--- a/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentCollection.cs
+++ b/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentCollection.cs
@@ -214,11 +214,12 @@ public sealed class MongoContentCollection : MongoRepositoryBase<MongoContentEnt
     }
 
     public async Task<Content?> FindContentAsync(Schema schema, DomainId id,
+        IEnumerable<string>? fields,
         CancellationToken ct)
     {
         using (Telemetry.Activities.StartActivity("MongoContentCollection/FindContentAsync"))
         {
-            return await queryBdId.QueryAsync(schema, id, ct);
+            return await queryBdId.QueryAsync(schema, id, fields, ct);
         }
     }
 

--- a/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentCollection.cs
+++ b/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentCollection.cs
@@ -213,8 +213,7 @@ public sealed class MongoContentCollection : MongoRepositoryBase<MongoContentEnt
         }
     }
 
-    public async Task<Content?> FindContentAsync(Schema schema, DomainId id,
-        IEnumerable<string>? fields,
+    public async Task<Content?> FindContentAsync(Schema schema, DomainId id, IEnumerable<string>? fields,
         CancellationToken ct)
     {
         using (Telemetry.Activities.StartActivity("MongoContentCollection/FindContentAsync"))

--- a/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentRepository.cs
+++ b/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentRepository.cs
@@ -106,8 +106,7 @@ public partial class MongoContentRepository(
         return GetCollection(scope).QueryAsync(app, schema, q, ct);
     }
 
-    public Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope,
-        IEnumerable<string>? fields,
+    public Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope, IEnumerable<string>? fields,
         CancellationToken ct = default)
     {
         return GetCollection(scope).FindContentAsync(schema, id, fields, ct);

--- a/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentRepository.cs
+++ b/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoContentRepository.cs
@@ -107,9 +107,10 @@ public partial class MongoContentRepository(
     }
 
     public Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope,
+        IEnumerable<string>? fields,
         CancellationToken ct = default)
     {
-        return GetCollection(scope).FindContentAsync(schema, id, ct);
+        return GetCollection(scope).FindContentAsync(schema, id, fields, ct);
     }
 
     public Task<IReadOnlyList<ContentIdStatus>> QueryIdsAsync(App app, HashSet<DomainId> ids, SearchScope scope,

--- a/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoShardedContentRepository.cs
+++ b/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/MongoShardedContentRepository.cs
@@ -22,9 +22,10 @@ public sealed class MongoShardedContentRepository(IShardingStrategy sharding, Fu
     : ShardedSnapshotStore<MongoContentRepository, WriteContent>(sharding, factory, x => x.AppId.Id), IContentRepository, IDeleter
 {
     public Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope,
+        IEnumerable<string>? fields,
         CancellationToken ct = default)
     {
-        return Shard(app.Id).FindContentAsync(app, schema, id, scope, ct);
+        return Shard(app.Id).FindContentAsync(app, schema, id, scope, fields, ct);
     }
 
     public Task<bool> HasReferrersAsync(App app, DomainId reference, SearchScope scope,

--- a/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/Operations/QueryById.cs
+++ b/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/Operations/QueryById.cs
@@ -15,11 +15,12 @@ namespace Squidex.Domain.Apps.Entities.Contents.Operations;
 internal sealed class QueryById : OperationBase
 {
     public async Task<Content?> QueryAsync(Schema schema, DomainId id,
+        IEnumerable<string>? fields,
         CancellationToken ct)
     {
         var filter = Filter.Eq(x => x.DocumentId, DomainId.Combine(schema.AppId, id));
 
-        var contentEntity = await Collection.Find(filter).SelectFields(null).FirstOrDefaultAsync(ct);
+        var contentEntity = await Collection.Find(filter).SelectFields(fields ?? null).FirstOrDefaultAsync(ct);
         if (contentEntity == null || contentEntity.IndexedSchemaId != schema.Id)
         {
             return null;

--- a/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/Operations/QueryById.cs
+++ b/backend/src/Squidex.Data.MongoDb/Domain/Apps/Entities/Contents/Operations/QueryById.cs
@@ -14,8 +14,7 @@ namespace Squidex.Domain.Apps.Entities.Contents.Operations;
 
 internal sealed class QueryById : OperationBase
 {
-    public async Task<Content?> QueryAsync(Schema schema, DomainId id,
-        IEnumerable<string>? fields,
+    public async Task<Content?> QueryAsync(Schema schema, DomainId id, IEnumerable<string>? fields,
         CancellationToken ct)
     {
         var filter = Filter.Eq(x => x.DocumentId, DomainId.Combine(schema.AppId, id));

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/ConvertContent/AddDefaultValues.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/ConvertContent/AddDefaultValues.cs
@@ -46,6 +46,19 @@ public sealed class AddDefaultValues(PartitionResolver partitionResolver, IClock
             data[field.Name] = [];
         }
     }
+    
+    public void ConvertDataAfter(Schema schema, ContentData data)
+    {
+        foreach (var field in schema.Fields)
+        {
+            if (FieldNames?.Contains(field.Name) == true)
+            {
+                continue;
+            }
+
+            data[field.Name] = [];
+        }
+    }
 
     public ContentFieldData? ConvertFieldAfter(IRootField field, ContentFieldData source)
     {

--- a/backend/src/Squidex.Domain.Apps.Entities/Contents/Queries/ContentQueryService.cs
+++ b/backend/src/Squidex.Domain.Apps.Entities/Contents/Queries/ContentQueryService.cs
@@ -277,7 +277,7 @@ public sealed class ContentQueryService(
             // Enforce a hard timeout
             combined.CancelAfter(options.TimeoutFind);
 
-            return await contentRepository.FindContentAsync(context.App, schema, id, context.Scope(), combined.Token);
+            return await contentRepository.FindContentAsync(context.App, schema, id, context.Scope(), context.Fields(), combined.Token);
         }
     }
 

--- a/backend/src/Squidex.Domain.Apps.Entities/Contents/Repositories/IContentRepository.cs
+++ b/backend/src/Squidex.Domain.Apps.Entities/Contents/Repositories/IContentRepository.cs
@@ -41,8 +41,7 @@ public interface IContentRepository
     Task<IReadOnlyList<ContentIdStatus>> QueryIdsAsync(App app, HashSet<DomainId> ids, SearchScope scope,
         CancellationToken ct = default);
 
-    Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope,
-        IEnumerable<string>? fields,
+    Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope, IEnumerable<string>? fields,
         CancellationToken ct = default);
 
     Task<bool> HasReferrersAsync(App app, DomainId reference, SearchScope scope,

--- a/backend/src/Squidex.Domain.Apps.Entities/Contents/Repositories/IContentRepository.cs
+++ b/backend/src/Squidex.Domain.Apps.Entities/Contents/Repositories/IContentRepository.cs
@@ -42,6 +42,7 @@ public interface IContentRepository
         CancellationToken ct = default);
 
     Task<Content?> FindContentAsync(App app, Schema schema, DomainId id, SearchScope scope,
+        IEnumerable<string>? fields,
         CancellationToken ct = default);
 
     Task<bool> HasReferrersAsync(App app, DomainId reference, SearchScope scope,


### PR DESCRIPTION
Try to add fields to FindContentAsync.
- Add the fields to the `SelectFields` method.
- Try to implement a converter in `AddDefaultValue`.

- [ ] Whether we need to handle fields in [EFContentRepository](https://github.com/sgalcheung/squidex/commit/aa1a9de9ecd2ece83c4aef67066f345989f39530#diff-e8b31054ee95f9f224e18f69b12fadd1bab98649fd3a67f54608754e3f9b402fR31).
- [ ] If we add a converter before sorting out these converters.

reference: [API: content/{app}/{schema}/{api} seems have some bugs](https://support.squidex.io/t/api-content-app-schema-api-seems-have-some-bugs/5907)