### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Build
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
@@ -65,7 +65,7 @@ jobs:
           node-version: 18
 
       - name: Build
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
           DOCKER_BUILD_SUMMARY: false
@@ -166,7 +166,7 @@ jobs:
           node-version: 18
 
       - name: Build
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
           DOCKER_BUILD_SUMMARY: false
@@ -243,7 +243,7 @@ jobs:
 
       - name: Build & Push for Multi-Platforms
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 18
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         with:
           load: true
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Build
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
@@ -60,7 +60,7 @@ jobs:
           node-version: 18
 
       - name: Build
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
           DOCKER_BUILD_SUMMARY: false
@@ -161,7 +161,7 @@ jobs:
           node-version: 18
 
       - name: Build
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
           DOCKER_BUILD_SUMMARY: false
@@ -243,7 +243,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build & Push for Multi-Platforms
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.17.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.17.0](https://github.com/docker/build-push-action/releases/tag/v6.17.0)** on 2025-05-15T12:49:16Z
