### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Build
         uses: docker/build-push-action@v6.18.0
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Prepare - Setup dotnet
         uses: actions/setup-dotnet@v4.3.1
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Prepare - Setup dotnet
         uses: actions/setup-dotnet@v4.3.1
@@ -220,7 +220,7 @@ jobs:
         uses: docker/setup-qemu-action@v3.6.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Prepare - Remove unnecessary files
         run: |

--- a/.github/workflows/make-screenshots.yml
+++ b/.github/workflows/make-screenshots.yml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/setup-qemu-action@v3.6.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Prepare - Setup Node
         uses: actions/setup-node@v4.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Build
         uses: docker/build-push-action@v6.18.0
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Prepare - Setup dotnet
         uses: actions/setup-dotnet@v4.3.1
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Prepare - Setup dotnet
         uses: actions/setup-dotnet@v4.3.1
@@ -215,7 +215,7 @@ jobs:
         uses: docker/setup-qemu-action@v3.6.0
 
       - name: Prepare - Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Prepare - Remove unnecessary files
         run: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.11.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.1)** on 2025-06-18T08:40:20Z
