### PR TITLE
Fix bulkMany error notification

### DIFF
--- a/frontend/src/app/shared/state/contents.state.ts
+++ b/frontend/src/app/shared/state/contents.state.ts
@@ -406,14 +406,9 @@ export abstract class ContentsStateBase extends State<Snapshot> {
             }),
             tap(results => {
                 const errors = results.filter(x => !!x.error);
-
                 if (errors.length > 0) {
-                    const error = errors[0].error!;
-
-                    if (errors.length >= contents.length) {
-                        throw error;
-                    } else {
-                        this.dialogs.notifyError(error.toError());
+                    for (let error of errors) {
+                        this.dialogs.notifyError(error.error!.toError());
                     }
                 }
             }));


### PR DESCRIPTION
An empty error dialog appears because an error is thrown when calling bulkmany when deleting from a single page content screen or a list screen.
The goal of this commit is to ensure that the error pop-up that occurs after calling bulkmany is displayed without any problems.