### PR TITLE
Refactor correctly handle empty response with ignore error flag is true

### DIFF
--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineHelperTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineHelperTests.cs
@@ -819,7 +819,7 @@ public class JintScriptEngineHelperTests : IClassFixture<TranslationsFixture>
         {
         };
 
-        string script = $@"
+        var script = $@"
                 var url = 'http://squidex.io/';
                 var hasRequestBodyMethods = ['patchJSON', 'postJSON', 'putJSON']
 


### PR DESCRIPTION
This PR handles cases where the body is empty, but the response is correct when ignore errors are enabled in the script.
The existing code causes a script parsing error when the body is passed to the JSON parser in ignore error mode.

**reference**
https://github.com/Squidex/squidex/issues/1242#issuecomment-3200847512
[unitycloud-rest-api](https://services.docs.unity.com/economy-admin/v2/index.html#tag/Economy-Admin/operation/deleteConfigResource)