### PR TITLE
Fix resolve async promise timeout issue in Jint from 4.1.0 to 4.4.1

### DIFF
--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JsonMapper.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JsonMapper.cs
@@ -109,6 +109,11 @@ public static class JsonMapper
             return number;
         }
 
+        if (value.IsPromise())
+        {
+            return Map(value.UnwrapIfPromise());
+        }
+
         if (value is JsArray a)
         {
             var result = new JsonArray((int)a.Length);

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
@@ -29,6 +29,7 @@ public sealed class JintScriptEngine(IMemoryCache cache, IOptions<JintScriptOpti
     private readonly CacheParser parser = new CacheParser(cache);
     private readonly TimeSpan timeoutScript = options.Value.TimeoutScript;
     private readonly TimeSpan timeoutExecution = options.Value.TimeoutExecution;
+    private readonly TimeSpan timeoutPromise = options.Value.TimeoutPromise;
 
     public async Task<JsonValue> ExecuteAsync(ScriptVars vars, string script, ScriptOptions options = default,
         CancellationToken ct = default)
@@ -150,6 +151,7 @@ public sealed class JintScriptEngine(IMemoryCache cache, IOptions<JintScriptOpti
 
             if (!Debugger.IsAttached)
             {
+                engineOptions.Constraints.PromiseTimeout = timeoutPromise;
                 engineOptions.TimeoutInterval(timeoutScript);
                 engineOptions.CancellationToken(ct);
             }

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptOptions.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptOptions.cs
@@ -12,4 +12,6 @@ public sealed class JintScriptOptions
     public TimeSpan TimeoutScript { get; set; } = TimeSpan.FromMilliseconds(200);
 
     public TimeSpan TimeoutExecution { get; set; } = TimeSpan.FromMilliseconds(4000);
+
+    public TimeSpan TimeoutPromise { get; set; } = TimeSpan.FromMilliseconds(4000);
 }

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Squidex.Domain.Apps.Core.Operations.csproj
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Squidex.Domain.Apps.Core.Operations.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Fluid.Core" Version="2.12.0" />
     <PackageReference Include="GeoJSON.Net" Version="1.4.1" />
-    <PackageReference Include="Jint" Version="4.1.0" />
+    <PackageReference Include="Jint" Version="4.4.1" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.179">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/src/Squidex/appsettings.json
+++ b/backend/src/Squidex/appsettings.json
@@ -126,7 +126,10 @@
         "timeoutExecution": "00:00:04",
 
         // The timeout for the synchronous part of the script.
-        "timeoutScript": "00:00:00.200"
+        "timeoutScript": "00:00:00.200",
+
+        // The timeout for the asynchronous promise of the script.
+        "timeoutPromise": "00:00:04"
     },
 
     "languages": {


### PR DESCRIPTION
This PR addresses an issue where promise timeouts were not triggered in Jint 4.1.0 by updating the library.
It also adds Jint's PromiseTimeout option, reflecting the latest version.
All Jint test cases passed.

**Issues Support**
[https://support.squidex.io/t/blocking-script](https://support.squidex.io/t/blocking-script)