### PR TITLE
Add ui disable option

### DIFF
--- a/backend/src/Squidex/Areas/Api/Controllers/UI/MyUIOptions.cs
+++ b/backend/src/Squidex/Areas/Api/Controllers/UI/MyUIOptions.cs
@@ -56,6 +56,9 @@ public sealed record MyUIOptions
     [JsonPropertyName("collaborationService")]
     public string CollaborationService { get; set; }
 
+    [JsonPropertyName("disable")]
+    public bool Disable { get; set; }
+
     public sealed class MapOptions
     {
         [JsonPropertyName("type")]

--- a/backend/src/Squidex/Areas/Frontend/Startup.cs
+++ b/backend/src/Squidex/Areas/Frontend/Startup.cs
@@ -7,6 +7,7 @@
 
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Net.Http.Headers;
+using Squidex.Areas.Api.Controllers.UI;
 using Squidex.Areas.Frontend.Middlewares;
 using Squidex.Hosting.Web;
 using Squidex.Pipeline.Squid;
@@ -17,8 +18,14 @@ namespace Squidex.Areas.Frontend;
 
 public static class Startup
 {
-    public static void UseFrontend(this IApplicationBuilder app)
+    public static void UseFrontend(this IApplicationBuilder app, IConfiguration config)
     {
+        var uiOptions = config.GetSection("ui").Get<MyUIOptions>();
+        if (uiOptions is { Disable: true })
+        {
+            return;
+        }
+
         var environment = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
 
         var fileProvider = environment.WebRootFileProvider;

--- a/backend/src/Squidex/Config/Domain/FontendServices.cs
+++ b/backend/src/Squidex/Config/Domain/FontendServices.cs
@@ -19,8 +19,14 @@ namespace Squidex.Config.Domain;
 
 public static class FontendServices
 {
-    public static void AddSquidexFrontend(this IServiceCollection services)
+    public static void AddSquidexFrontend(this IServiceCollection services, IConfiguration config)
     {
+        var uiOptions = config.GetSection("ui").Get<MyUIOptions>();
+        if (uiOptions is { Disable: true })
+        {
+            return;
+        }
+
         services.Configure<MyUIOptions>((services, options) =>
         {
             var jsonOptions = services.GetRequiredService<JsonSerializerOptions>();

--- a/backend/src/Squidex/Startup.cs
+++ b/backend/src/Squidex/Startup.cs
@@ -43,7 +43,7 @@ public sealed class Startup(IConfiguration config)
         services.AddSquidexContents(config);
         services.AddSquidexControllerServices(config);
         services.AddSquidexEventSourcing(config);
-        services.AddSquidexFrontend();
+        services.AddSquidexFrontend(config);
         services.AddSquidexGraphQL();
         services.AddSquidexHealthChecks(config);
         services.AddSquidexHistory(config);
@@ -119,7 +119,7 @@ public sealed class Startup(IConfiguration config)
             builder.Use404();
         });
 
-        app.UseFrontend();
+        app.UseFrontend(config);
         app.UsePlugins();
     }
 }

--- a/backend/src/Squidex/appsettings.json
+++ b/backend/src/Squidex/appsettings.json
@@ -149,6 +149,9 @@
     },
 
     "ui": {
+        // Admin UI disable
+        "disable": false,
+
         // Regex suggestions for the UI
         "regexSuggestions": {
             // Regex for emails.


### PR DESCRIPTION
This PR is submitted to disable the Squidex Frontend, supporting only the API server.
This is necessary for cases where UI pages are not exposed externally.