### PR TITLE
fix: register MongoDB AWS authentication for Atlas IAM (driver 3.x)

### DIFF
--- a/backend/src/Squidex.Data.MongoDb/MongoClientFactory.cs
+++ b/backend/src/Squidex.Data.MongoDb/MongoClientFactory.cs
@@ -8,6 +8,7 @@
 using System.Text.Json;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Authentication.AWS;
 using Squidex.Domain.Apps.Core.Contents;
 using Squidex.Domain.Apps.Entities;
 using Squidex.Domain.Apps.Entities.Assets;
@@ -23,6 +24,8 @@ namespace Squidex;
 
 public static class MongoClientFactory
 {
+    private static int awsAuthenticationRegistered;
+
     public static void SetupSerializer(JsonSerializerOptions jsonSerializerOptions, BsonType representation)
     {
         // Register the serializers first.
@@ -53,6 +56,11 @@ public static class MongoClientFactory
 
     public static MongoClient Create(string? connectionString, Action<MongoClientSettings>? configure = null)
     {
+        if (Interlocked.Exchange(ref awsAuthenticationRegistered, 1) == 0)
+        {
+            MongoClientSettings.Extensions.AddAWSAuthentication();
+        }
+
         var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
 
         // If we really need custom config.

--- a/backend/src/Squidex.Data.MongoDb/Squidex.Data.MongoDb.csproj
+++ b/backend/src/Squidex.Data.MongoDb/Squidex.Data.MongoDb.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MongoDB.Driver" Version="3.8.0" />
+    <PackageReference Include="MongoDB.Driver.Authentication.AWS" Version="3.8.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
     <PackageReference Include="RefactoringEssentials" Version="5.6.0" PrivateAssets="all" />


### PR DESCRIPTION
## Summary

Fixes startup failure when MongoDB is configured with Atlas IAM authentication (`authMechanism=MONGODB-AWS`).

Adds the `MongoDB.Driver.Authentication.AWS` package and registers the AWS auth provider in `MongoClientFactory.Create()`.

## Problem

Starting with MongoDB .NET Driver 3.0, `MONGODB-AWS` was moved out of the core driver into an optional package and must be registered explicitly. Squidex uses driver 3.x but does not register the extension, so Atlas IAM connection strings fail at startup.

Example connection string:
`mongodb+srv://cluster.example.mongodb.net/?authSource=%24external&authMechanism=MONGODB-AWS
`

## Error without this change

`
MongoDB.Driver.MongoConnectionException: An exception occurred while opening a connection to the server. ---> System.NotSupportedException: Unable to create an authenticator. at MongoDB.Driver.MongoCredential.ToAuthenticator(...) at MongoDB.Driver.Core.Connections.ConnectionInitializer.CreateAuthenticator(...) ... at Squidex.Hosting.InitializerHost.StartAsync(...)
`


The application never becomes ready.

## Root cause

Driver 2.x included `MONGODB-AWS` in the core package. Driver 3.x requires:

1. Package reference: `MongoDB.Driver.Authentication.AWS` (version aligned with `MongoDB.Driver`)
2. One-time registration: `MongoClientSettings.Extensions.AddAWSAuthentication()`

Without (2), the driver cannot resolve the SASL mechanism from the connection string.

## Changes

- `Squidex.Data.MongoDb.csproj` — add `MongoDB.Driver.Authentication.AWS` 3.8.0
- `MongoClientFactory.cs` — register AWS authentication once before creating a `MongoClient`

All Mongo clients in Squidex go through `MongoClientFactory.Create()` (via `ServiceExtensions`).

## Test plan

- [x] Verified on EKS with Atlas IAM connection string and IRSA
- [x] Application starts; `/healthz` and `/readiness` return 200
- [x] No `Unable to create an authenticator` in logs

## References

- [MongoDB C# Driver — AWS IAM Authentication](https://www.mongodb.com/docs/drivers/csharp/current/security/authentication/aws-iam/)
- [MongoDB .NET Driver 3.0 release notes (CSHARP-4911)](https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.0.0)

