### PR TITLE
Upgrade Jint to 4.15.3 and adopt its cache-gate and lazy-value APIs

### DIFF
--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/ContentWrapper/ContentFieldObject.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/ContentWrapper/ContentFieldObject.cs
@@ -132,6 +132,29 @@ public sealed class ContentFieldObject : ObjectInstance
         return valueProperties?.GetValueOrDefault(propertyName) ?? PropertyDescriptor.Undefined;
     }
 
+    protected override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        // Deliberately mirrors GetOwnProperty above, minus the descriptor: the flags are on the descriptor
+        // itself, so an existence or enumerability question is answered without ever reading CustomValue,
+        // which is what maps the JSON value to a JsValue. The engine trusts the answer without verifying it,
+        // so the two must stay in step.
+        EnsurePropertiesInitialized();
+
+        var propertyName = property.AsString();
+
+        if (propertyName.Equals("toJSON", StringComparison.OrdinalIgnoreCase))
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        if (!valueProperties.TryGetValue(propertyName, out var propertyDescriptor))
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        return propertyDescriptor.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
+    }
+
     public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
     {
         EnsurePropertiesInitialized();

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/ContentWrapper/ContentFieldObject.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/ContentWrapper/ContentFieldObject.cs
@@ -134,10 +134,10 @@ public sealed class ContentFieldObject : ObjectInstance
 
     protected override OwnPropertyProbe ProbeOwnProperty(JsValue property)
     {
-        // Deliberately mirrors GetOwnProperty above, minus the descriptor: the flags are on the descriptor
-        // itself, so an existence or enumerability question is answered without ever reading CustomValue,
-        // which is what maps the JSON value to a JsValue. The engine trusts the answer without verifying it,
-        // so the two must stay in step.
+        // Answers whether a key exists without converting its value, which reading the property would do.
+        // Used by "in", hasOwnProperty, Object.keys, spread and JSON.stringify. Must give the same answer as
+        // GetOwnProperty above, which Jint does not check at runtime, only in tests (see
+        // JintHostContractVerification), so the two methods are kept identical apart from the return value.
         EnsurePropertiesInitialized();
 
         var propertyName = property.AsString();

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintExtensions.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintExtensions.cs
@@ -74,9 +74,8 @@ public static class JintExtensions
         {
             foreach (var (key, item) in vars)
             {
-                // Deferred instead of Engine.SetValue, which maps every variable now. The global itself is
-                // installed eagerly, so existence checks and enumeration see the name without materializing
-                // anything; only the mapping waits for the first read of the value.
+                // Sets the value, but runs the conversion only when the script reads it for the first time.
+                // The name is added right away, so enumeration and "in" checks work as before.
                 engine.Advanced.AddLazyGlobal(key, e => MapVariable(e, item));
             }
         }
@@ -87,8 +86,8 @@ public static class JintExtensions
     }
 
     /// <summary>
-    /// The conversion <see cref="Engine.SetValue(string, object)"/> performs, including its special case for
-    /// a CLR type, so deferring a variable cannot change what the script sees.
+    /// Converts a value exactly like <see cref="Engine.SetValue(string, object)"/> does, including its
+    /// special case for types, so that a deferred variable cannot look different from an eager one.
     /// </summary>
     private static JsValue MapVariable(Engine engine, object? item)
     {

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintExtensions.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintExtensions.cs
@@ -7,6 +7,7 @@
 
 using Jint;
 using Jint.Native;
+using Jint.Runtime.Interop;
 using Squidex.Infrastructure;
 
 namespace Squidex.Domain.Apps.Core.Scripting.Internal;
@@ -73,12 +74,29 @@ public static class JintExtensions
         {
             foreach (var (key, item) in vars)
             {
-                engine.SetValue(key, item);
+                // Deferred instead of Engine.SetValue, which maps every variable now. The global itself is
+                // installed eagerly, so existence checks and enumeration see the name without materializing
+                // anything; only the mapping waits for the first read of the value.
+                engine.Advanced.AddLazyGlobal(key, e => MapVariable(e, item));
             }
         }
 
         engine.SetValue("async", true);
 
         return context;
+    }
+
+    /// <summary>
+    /// The conversion <see cref="Engine.SetValue(string, object)"/> performs, including its special case for
+    /// a CLR type, so deferring a variable cannot change what the script sees.
+    /// </summary>
+    private static JsValue MapVariable(Engine engine, object? item)
+    {
+        if (item is Type type)
+        {
+            return TypeReference.CreateTypeReference(engine, type);
+        }
+
+        return JsValue.FromObject(engine, item);
     }
 }

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintObjectConverter.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintObjectConverter.cs
@@ -22,14 +22,14 @@ namespace Squidex.Domain.Apps.Core.Scripting.Internal;
 public sealed class JintObjectConverter : IObjectConverter
 {
     /// <summary>
-    /// The CLR types this converter answers for, declared at registration so the engine can keep its
-    /// compiled interop member-read lane for members whose declared type can never reach this converter.
+    /// The types this converter handles, passed to Jint when the converter is registered.
     /// </summary>
     /// <remarks>
-    /// Matching is by assignability, so <see cref="IUser"/> covers every implementation. Registering the
-    /// converter without this set makes every wrapped CLR member read in the engine take the slow lane.
-    /// Enums are not listed: they are handled natively through
-    /// <see cref="Options.InteropOptions.EnumConversion"/>.
+    /// Without this list Jint has to offer every property of every .NET object to this converter and cannot
+    /// use its faster property reader for any of them. Base types and interfaces count, so
+    /// <see cref="IUser"/> covers all implementations. Keep the list in sync with the switch below - a type
+    /// that is converted but not listed here fails a test (see JintHostContractVerification). Enums are
+    /// missing on purpose, they are converted by Jint itself, see EnumConversion in JintScriptEngine.
     /// </remarks>
     public static readonly Type[] HandledTypes =
     [

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintObjectConverter.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JintObjectConverter.cs
@@ -21,6 +21,29 @@ namespace Squidex.Domain.Apps.Core.Scripting.Internal;
 
 public sealed class JintObjectConverter : IObjectConverter
 {
+    /// <summary>
+    /// The CLR types this converter answers for, declared at registration so the engine can keep its
+    /// compiled interop member-read lane for members whose declared type can never reach this converter.
+    /// </summary>
+    /// <remarks>
+    /// Matching is by assignability, so <see cref="IUser"/> covers every implementation. Registering the
+    /// converter without this set makes every wrapped CLR member read in the engine take the slow lane.
+    /// Enums are not listed: they are handled natively through
+    /// <see cref="Options.InteropOptions.EnumConversion"/>.
+    /// </remarks>
+    public static readonly Type[] HandledTypes =
+    [
+        typeof(IUser),
+        typeof(ClaimsPrincipal),
+        typeof(ScriptVars),
+        typeof(JsonValue),
+        typeof(DomainId),
+        typeof(Guid),
+        typeof(Instant),
+        typeof(Status),
+        typeof(ContentData),
+    ];
+
     public static readonly JintObjectConverter Instance = new JintObjectConverter();
 
     private JintObjectConverter()
@@ -30,12 +53,6 @@ public sealed class JintObjectConverter : IObjectConverter
     public bool TryConvert(Engine engine, object value, [MaybeNullWhen(false)] out JsValue result)
     {
         result = null!;
-
-        if (value is Enum)
-        {
-            result = value.ToString();
-            return true;
-        }
 
         switch (value)
         {

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JsonMapper.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JsonMapper.cs
@@ -55,9 +55,9 @@ public static class JsonMapper
 
     private static JsObject FromObject(JsonObject obj, Engine engine)
     {
-        // Built through the hidden class machinery, so JSON objects sharing a key sequence - every content
-        // item of the same schema does - share one hidden class and keep a script reading them monomorphic.
-        // A bare ObjectInstance subclass can never be in shape mode and is outside the read caches entirely.
+        // Objects that are created this way and have the same keys - all content items of a schema do -
+        // share one description of their layout, like a class. Reading a property is then a lot faster than
+        // with a custom ObjectInstance class, where every single object gets its own property dictionary.
         var entries = new KeyValuePair<string, JsValue>[obj.Count];
 
         var index = 0;
@@ -119,8 +119,8 @@ public static class JsonMapper
 
             var result = new JsonArray((int)length);
 
-            // The indexed accessor reads the dense backing directly, where a string key would allocate one
-            // key per element and route through the full property lookup.
+            // The indexer reads the array storage directly. The old version converted the index to a string
+            // and did a full property lookup for every element.
             for (var i = 0u; i < length; i++)
             {
                 result.Add(Map(a[i]));

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JsonMapper.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/Internal/JsonMapper.cs
@@ -6,7 +6,6 @@
 // ==========================================================================
 
 using System.Collections;
-using System.Globalization;
 using Jint;
 using Jint.Native;
 using Jint.Native.Object;
@@ -18,10 +17,6 @@ namespace Squidex.Domain.Apps.Core.Scripting.Internal;
 
 public static class JsonMapper
 {
-    private sealed class JsonObjectInstance(Engine engine) : ObjectInstance(engine)
-    {
-    }
-
     public static JsValue Map(JsonValue value, Engine engine)
     {
         switch (value.Value)
@@ -33,9 +28,9 @@ public static class JsonMapper
             case false:
                 return JsBoolean.False;
             case double n:
-                return new JsNumber(n);
+                return JsNumber.Create(n);
             case string s:
-                return new JsString(s);
+                return JsString.Create(s);
             case JsonObject o:
                 return FromObject(o, engine);
             case JsonArray a:
@@ -58,16 +53,20 @@ public static class JsonMapper
         return engine.Intrinsics.Array.Construct(target);
     }
 
-    private static JsonObjectInstance FromObject(JsonObject obj, Engine engine)
+    private static JsObject FromObject(JsonObject obj, Engine engine)
     {
-        var target = new JsonObjectInstance(engine);
+        // Built through the hidden class machinery, so JSON objects sharing a key sequence - every content
+        // item of the same schema does - share one hidden class and keep a script reading them monomorphic.
+        // A bare ObjectInstance subclass can never be in shape mode and is outside the read caches entirely.
+        var entries = new KeyValuePair<string, JsValue>[obj.Count];
 
+        var index = 0;
         foreach (var (key, value) in obj)
         {
-            target.Set(key, Map(value, engine));
+            entries[index++] = new KeyValuePair<string, JsValue>(key, Map(value, engine));
         }
 
-        return target;
+        return JsObject.CreateFromEntries(engine, entries);
     }
 
     public static JsonValue Map(JsValue? value)
@@ -116,11 +115,15 @@ public static class JsonMapper
 
         if (value is JsArray a)
         {
-            var result = new JsonArray((int)a.Length);
+            var length = a.Length;
 
-            for (var i = 0; i < a.Length; i++)
+            var result = new JsonArray((int)length);
+
+            // The indexed accessor reads the dense backing directly, where a string key would allocate one
+            // key per element and route through the full property lookup.
+            for (var i = 0u; i < length; i++)
             {
-                result.Add(Map(a.Get(i.ToString(CultureInfo.InvariantCulture))));
+                result.Add(Map(a[i]));
             }
 
             return result;

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
@@ -146,7 +146,7 @@ public sealed class JintScriptEngine(IMemoryCache cache, IOptions<JintScriptOpti
             engineOptions.AddObjectConverter(JintObjectConverter.Instance);
             engineOptions.AllowClrWrite(!options.Readonly);
             engineOptions.SetTypeConverter(engine => new CustomClrConverter(engine));
-            engineOptions.SetReferencesResolver(NullPropagation.Instance);
+            engineOptions.SetReferencesResolver(NullPropagation.Instance, NullPropagation.Interests);
             engineOptions.Strict();
 
             if (!Debugger.IsAttached)

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
@@ -145,7 +145,10 @@ public sealed class JintScriptEngine(IMemoryCache cache, IOptions<JintScriptOpti
         {
             engineOptions.AddObjectConverter(JintObjectConverter.Instance, JintObjectConverter.HandledTypes);
             engineOptions.AllowClrWrite(!options.Readonly);
+
+            // Converts enums to their name, e.g. "Published". This was done by JintObjectConverter before.
             engineOptions.Interop.EnumConversion = EnumConversionMode.String;
+
             engineOptions.SetTypeConverter(engine => new CustomClrConverter(engine));
             engineOptions.SetReferencesResolver(NullPropagation.Instance, NullPropagation.Interests);
             engineOptions.Strict();

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/JintScriptEngine.cs
@@ -143,8 +143,9 @@ public sealed class JintScriptEngine(IMemoryCache cache, IOptions<JintScriptOpti
 
         var engine = new Engine(engineOptions =>
         {
-            engineOptions.AddObjectConverter(JintObjectConverter.Instance);
+            engineOptions.AddObjectConverter(JintObjectConverter.Instance, JintObjectConverter.HandledTypes);
             engineOptions.AllowClrWrite(!options.Readonly);
+            engineOptions.Interop.EnumConversion = EnumConversionMode.String;
             engineOptions.SetTypeConverter(engine => new CustomClrConverter(engine));
             engineOptions.SetReferencesResolver(NullPropagation.Instance, NullPropagation.Interests);
             engineOptions.Strict();

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/NullPropagation.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/NullPropagation.cs
@@ -15,17 +15,13 @@ namespace Squidex.Domain.Apps.Core.Scripting;
 public sealed class NullPropagation : IReferenceResolver
 {
     /// <summary>
-    /// The situations this resolver actually answers, declared so the engine keeps the fast paths for
-    /// everything else.
+    /// The cases this resolver actually handles.
     /// </summary>
     /// <remarks>
-    /// Deliberately omitted are <see cref="ReferenceResolverInterests.ObjectPropertyBase"/> and
-    /// <see cref="ReferenceResolverInterests.PrimitivePropertyBase"/>, the pair that disables the
-    /// non-computed member-read inline caches, the dense-array indexed-read lane and the member-call callee
-    /// lane engine-wide. <see cref="TryPropertyReference"/> declines every base that is not null or
-    /// undefined, so those are situations where the engine consulting this resolver could never change the
-    /// result. Interests are a subscription filter and not a promise: a situation not subscribed to behaves
-    /// exactly as if no resolver were registered.
+    /// Without this list Jint has to assume that we want to see every property read and turns off its read
+    /// caches for the whole engine. But <see cref="TryPropertyReference"/> only ever does something when the
+    /// value is null or undefined, so the other cases can be left to Jint. Behavior does not change: for a
+    /// case that is not listed here Jint behaves as if no resolver was registered at all.
     /// </remarks>
     public const ReferenceResolverInterests Interests =
         ReferenceResolverInterests.NullishPropertyBase |
@@ -35,16 +31,12 @@ public sealed class NullPropagation : IReferenceResolver
     public static readonly NullPropagation Instance = new NullPropagation();
 
     /// <summary>
-    /// Answers a read of a name that resolves to no binding, so that an unknown name does not throw a
-    /// reference error.
+    /// Called when a name does not exist, so that reading an unknown variable does not throw.
     /// </summary>
     /// <remarks>
-    /// Passing the reference base straight through hands script the engine's internal sentinel for the
-    /// unresolvable state - a <see cref="JsString"/> reading <c>[[Unresolvable]]</c> - rather than
-    /// <c>undefined</c>, which is documented on <see cref="IReferenceResolver.TryUnresolvableReference"/> and
-    /// on <see cref="Reference.Base"/>. That is what scripts have always seen here, so it is kept and pinned
-    /// by a test; assigning <see cref="JsValue.Undefined"/> instead would be the tidier behaviour but a
-    /// breaking change for existing tenant scripts.
+    /// The returned base is not <c>undefined</c> here but an internal Jint marker string that reads
+    /// <c>[[Unresolvable]]</c>. That is what scripts have always seen, so it is kept as it is and covered by
+    /// a test. Returning <c>undefined</c> would be nicer, but would change behavior for existing scripts.
     /// </remarks>
     public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
     {

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/NullPropagation.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/NullPropagation.cs
@@ -14,8 +14,38 @@ namespace Squidex.Domain.Apps.Core.Scripting;
 
 public sealed class NullPropagation : IReferenceResolver
 {
+    /// <summary>
+    /// The situations this resolver actually answers, declared so the engine keeps the fast paths for
+    /// everything else.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately omitted are <see cref="ReferenceResolverInterests.ObjectPropertyBase"/> and
+    /// <see cref="ReferenceResolverInterests.PrimitivePropertyBase"/>, the pair that disables the
+    /// non-computed member-read inline caches, the dense-array indexed-read lane and the member-call callee
+    /// lane engine-wide. <see cref="TryPropertyReference"/> declines every base that is not null or
+    /// undefined, so those are situations where the engine consulting this resolver could never change the
+    /// result. Interests are a subscription filter and not a promise: a situation not subscribed to behaves
+    /// exactly as if no resolver were registered.
+    /// </remarks>
+    public const ReferenceResolverInterests Interests =
+        ReferenceResolverInterests.NullishPropertyBase |
+        ReferenceResolverInterests.UnresolvableReference |
+        ReferenceResolverInterests.NonCallableCallee;
+
     public static readonly NullPropagation Instance = new NullPropagation();
 
+    /// <summary>
+    /// Answers a read of a name that resolves to no binding, so that an unknown name does not throw a
+    /// reference error.
+    /// </summary>
+    /// <remarks>
+    /// Passing the reference base straight through hands script the engine's internal sentinel for the
+    /// unresolvable state - a <see cref="JsString"/> reading <c>[[Unresolvable]]</c> - rather than
+    /// <c>undefined</c>, which is documented on <see cref="IReferenceResolver.TryUnresolvableReference"/> and
+    /// on <see cref="Reference.Base"/>. That is what scripts have always seen here, so it is kept and pinned
+    /// by a test; assigning <see cref="JsValue.Undefined"/> instead would be the tidier behaviour but a
+    /// breaking change for existing tenant scripts.
+    /// </remarks>
     public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
     {
         value = reference.Base;

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/WritableContext.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/WritableContext.cs
@@ -1,4 +1,4 @@
-﻿// ==========================================================================
+// ==========================================================================
 //  Squidex Headless CMS
 // ==========================================================================
 //  Copyright (c) Squidex UG (haftungsbeschraenkt)
@@ -8,6 +8,7 @@
 using Jint;
 using Jint.Native;
 using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
 
 namespace Squidex.Domain.Apps.Core.Scripting;
 
@@ -20,9 +21,17 @@ internal sealed class WritableContext : ObjectInstance
     {
         this.vars = vars;
 
+        // Scripts touch a fraction of the variables, but mapping one is not always cheap: a content data
+        // variable builds a wrapper, a user variable walks and groups every claim. The descriptors are
+        // installed eagerly - so key order, enumeration and existence checks are exactly what they were -
+        // and only the mapping waits for the first read of a value. Once it has run the descriptor drops
+        // back to an ordinary data property and rejoins the write inline cache, which is what a
+        // hand-written CustomJsValue descriptor cannot do.
         foreach (var (key, item) in vars)
         {
-            base.Set(key, FromObject(engine, item), this);
+            SetOwnProperty(key, PropertyDescriptor.CreateLazy(
+                (Engine: engine, Item: item),
+                static state => FromObject(state.Engine, state.Item)));
         }
     }
 

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/WritableContext.cs
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Scripting/WritableContext.cs
@@ -21,12 +21,10 @@ internal sealed class WritableContext : ObjectInstance
     {
         this.vars = vars;
 
-        // Scripts touch a fraction of the variables, but mapping one is not always cheap: a content data
-        // variable builds a wrapper, a user variable walks and groups every claim. The descriptors are
-        // installed eagerly - so key order, enumeration and existence checks are exactly what they were -
-        // and only the mapping waits for the first read of a value. Once it has run the descriptor drops
-        // back to an ordinary data property and rejoins the write inline cache, which is what a
-        // hand-written CustomJsValue descriptor cannot do.
+        // Adds the value, but runs the conversion only when the script reads it for the first time. Most
+        // scripts use a few of these variables and some of them are expensive, e.g. the user variable walks
+        // and groups all claims. The properties themselves are added right away, so key order, enumeration
+        // and "in" checks stay the same.
         foreach (var (key, item) in vars)
         {
             SetOwnProperty(key, PropertyDescriptor.CreateLazy(

--- a/backend/src/Squidex.Domain.Apps.Core.Operations/Squidex.Domain.Apps.Core.Operations.csproj
+++ b/backend/src/Squidex.Domain.Apps.Core.Operations/Squidex.Domain.Apps.Core.Operations.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Fluid.Core" Version="2.31.0" />
     <PackageReference Include="GeoJSON.Net" Version="1.4.1" />
-    <PackageReference Include="Jint" Version="4.8.0" />
+    <PackageReference Include="Jint" Version="4.15.3" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.50">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/ContentDataObjectTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/ContentDataObjectTests.cs
@@ -409,6 +409,138 @@ public class ContentDataObjectTests
         ExecuteScript([], script);
     }
 
+    [Fact]
+    public void Should_answer_in_operator_for_field_values()
+    {
+        const string script = @"
+                ('iv' in data.string) + ',' + ('unknown' in data.string);
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("true,false", actual);
+    }
+
+    [Fact]
+    public void Should_answer_has_own_property_for_field_values()
+    {
+        const string script = @"
+                data.string.hasOwnProperty('iv') + ',' + data.string.hasOwnProperty('unknown');
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("true,false", actual);
+    }
+
+    [Fact]
+    public void Should_list_field_value_keys()
+    {
+        const string script = @"
+                Object.keys(data.string).join(',');
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("iv,de", actual);
+    }
+
+    [Fact]
+    public void Should_report_field_values_as_enumerable()
+    {
+        const string script = @"
+                data.string.propertyIsEnumerable('iv') + ',' + data.string.propertyIsEnumerable('unknown');
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("true,false", actual);
+    }
+
+    [Fact]
+    public void Should_stringify_field_values()
+    {
+        const string script = @"
+                JSON.stringify(data.string);
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("{\"iv\":\"1\",\"de\":\"2\"}", actual);
+    }
+
+    [Fact]
+    public void Should_stringify_content_data()
+    {
+        const string script = @"
+                JSON.stringify(data);
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("{\"string\":{\"iv\":\"1\",\"de\":\"2\"},\"number\":{\"iv\":42}}", actual);
+    }
+
+    [Fact]
+    public void Should_spread_field_values()
+    {
+        const string script = @"
+                JSON.stringify({ ...data.string });
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("{\"iv\":\"1\",\"de\":\"2\"}", actual);
+    }
+
+    [Fact]
+    public void Should_not_see_deleted_field_values()
+    {
+        const string script = @"
+                delete data.string.de;
+                ('de' in data.string) + ',' + Object.keys(data.string).join(',');
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("false,iv", actual);
+    }
+
+    [Fact]
+    public void Should_see_added_field_values()
+    {
+        const string script = @"
+                data.string.en = '3';
+                ('en' in data.string) + ',' + Object.keys(data.string).join(',');
+            ";
+
+        var actual = EvaluateScript(CreateContent(), script);
+
+        Assert.Equal("true,iv,de,en", actual);
+    }
+
+    private static ContentData CreateContent()
+    {
+        return
+            new ContentData()
+                .AddField("string",
+                    new ContentFieldData()
+                        .AddInvariant("1")
+                        .AddLocalized("de", "2"))
+                .AddField("number",
+                    new ContentFieldData()
+                        .AddInvariant(42));
+    }
+
+    private static object? EvaluateScript(ContentData original, string script)
+    {
+        var engine = new Engine(o => o.Strict());
+
+        engine.SetValue("data", new ContentDataObject(engine, original));
+
+        return engine.Evaluate(script).ToObject();
+    }
+
     private static ContentData ExecuteScript(ContentData original, string script)
     {
         var engine = new Engine(o => o.Strict());

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineTests.cs
@@ -729,9 +729,8 @@ public class JintScriptEngineTests : IClassFixture<TranslationsFixture>
     [Fact]
     public void Should_not_throw_if_reading_undeclared_identifier()
     {
-        // The null propagation resolver answers an unresolvable reference with the reference base, which is
-        // Jint's internal sentinel. The value is odd, but it is what scripts have always seen and the point
-        // of the test is that the read does not throw a reference error.
+        // Reading an unknown name does not throw, it returns an internal Jint marker string. That is odd,
+        // but it is what scripts have always seen here, see NullPropagation.TryUnresolvableReference.
         const string script = @"
                 String(unknownName) + '|' + (typeof unknownName);
             ";

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineTests.cs
@@ -725,4 +725,351 @@ public class JintScriptEngineTests : IClassFixture<TranslationsFixture>
 
         Assert.Equal(42.0, result.Value);
     }
+
+    [Fact]
+    public void Should_not_throw_if_reading_undeclared_identifier()
+    {
+        // The null propagation resolver answers an unresolvable reference with the reference base, which is
+        // Jint's internal sentinel. The value is odd, but it is what scripts have always seen and the point
+        // of the test is that the read does not throw a reference error.
+        const string script = @"
+                String(unknownName) + '|' + (typeof unknownName);
+            ";
+
+        var actual = sut.Execute(new ScriptVars(), script);
+
+        Assert.Equal(JsonValue.Create("[[Unresolvable]]|undefined"), actual);
+    }
+
+    [Fact]
+    public void Should_null_propagate_over_nullish_property_base()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = 13,
+        };
+
+        const string script = @"
+                ctx.unknown.deeper.evenDeeper === undefined;
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.True, actual);
+    }
+
+    [Fact]
+    public void Should_chain_call_over_nullish_property_base()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = 13,
+        };
+
+        const string script = @"
+                ctx.unknown.deeper.someMethod() === undefined;
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.True, actual);
+    }
+
+    [Fact]
+    public void Should_return_base_if_calling_non_callable_member()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = "squidex",
+        };
+
+        const string script = @"
+                ctx.value.notAFunction();
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("squidex"), actual);
+    }
+
+    [Fact]
+    public void Should_not_change_normal_member_reads_and_calls()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = JsonValue.Create(new JsonObject().Add("name", JsonValue.Create("squidex"))),
+        };
+
+        const string script = @"
+                ctx.value.name.toUpperCase();
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("SQUIDEX"), actual);
+    }
+
+    [Fact]
+    public void Should_convert_enum_to_name()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = ScriptScope.ContentScript,
+        };
+
+        const string script = @"
+                value;
+            ";
+
+        var actual = sut.Execute(vars, script);
+
+        Assert.Equal(JsonValue.Create("ContentScript"), actual);
+    }
+
+    [Fact]
+    public void Should_convert_flags_enum_to_names()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = ScriptScope.ContentScript | ScriptScope.Transform,
+        };
+
+        const string script = @"
+                value;
+            ";
+
+        var actual = sut.Execute(vars, script);
+
+        Assert.Equal(JsonValue.Create("ContentScript, Transform"), actual);
+    }
+
+    [Fact]
+    public void Should_convert_enum_member_of_wrapped_object_to_name()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = new { scope = ScriptScope.Transform },
+        };
+
+        const string script = @"
+                value.scope;
+            ";
+
+        var actual = sut.Execute(vars, script);
+
+        Assert.Equal(JsonValue.Create("Transform"), actual);
+    }
+
+    [Fact]
+    public void Should_project_json_object_with_source_key_order()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = CreateJson(),
+        };
+
+        const string script = @"
+                Object.keys(ctx.value).join(',');
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("name,count,nested,items"), actual);
+    }
+
+    [Fact]
+    public void Should_stringify_projected_json_object()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = CreateJson(),
+        };
+
+        const string script = @"
+                JSON.stringify(ctx.value);
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(
+            JsonValue.Create("{\"name\":\"squidex\",\"count\":3,\"nested\":{\"flag\":true},\"items\":[1,2]}"),
+            actual);
+    }
+
+    [Fact]
+    public void Should_enumerate_projected_json_object()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = CreateJson(),
+        };
+
+        const string script = @"
+                var actual = [];
+                for (var key in ctx.value) {
+                    actual.push(key + '=' + (typeof ctx.value[key]));
+                }
+                actual.join(',');
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(
+            JsonValue.Create("name=string,count=number,nested=object,items=object"),
+            actual);
+    }
+
+    [Fact]
+    public void Should_allow_mutation_of_projected_json_object()
+    {
+        var vars = new ScriptVars
+        {
+            ["value"] = CreateJson(),
+        };
+
+        const string script = @"
+                ctx.value.name = 'changed';
+                ctx.value.added = 42;
+                delete ctx.value.count;
+                ctx.value;
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        var expected =
+            JsonValue.Create(
+                new JsonObject()
+                    .Add("name", JsonValue.Create("changed"))
+                    .Add("nested", JsonValue.Create(new JsonObject().Add("flag", JsonValue.True)))
+                    .Add("items", JsonValue.Create(new JsonArray().Add(JsonValue.Create(1)).Add(JsonValue.Create(2))))
+                    .Add("added", JsonValue.Create(42)));
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Should_round_trip_projected_json_object()
+    {
+        var json = CreateJson();
+
+        var vars = new ScriptVars
+        {
+            ["value"] = json,
+        };
+
+        const string script = @"
+                ctx.value;
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(json, actual);
+    }
+
+    [Fact]
+    public void Should_enumerate_context_keys()
+    {
+        const string script = @"
+                Object.keys(ctx).join(',');
+            ";
+
+        var actual = sut.Execute(CreateVars(), script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("number,text,json,user"), actual);
+    }
+
+    [Fact]
+    public void Should_answer_in_operator_for_context_keys()
+    {
+        const string script = @"
+                ('json' in ctx) + ',' + ('unknown' in ctx);
+            ";
+
+        var actual = sut.Execute(CreateVars(), script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("true,false"), actual);
+    }
+
+    [Fact]
+    public void Should_report_types_of_context_values()
+    {
+        const string script = @"
+                var actual = [];
+                for (var key in ctx) {
+                    actual.push(key + '=' + (typeof ctx[key]));
+                }
+                actual.join(',');
+            ";
+
+        var actual = sut.Execute(CreateVars(), script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("number=number,text=string,json=object,user=object"), actual);
+    }
+
+    [Fact]
+    public void Should_read_context_values()
+    {
+        const string script = @"
+                ctx.number + '|' + ctx.text + '|' + ctx.json.name + '|' + ctx.user.id;
+            ";
+
+        var actual = sut.Execute(CreateVars(), script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("13|hello|squidex|user1"), actual);
+    }
+
+    [Fact]
+    public void Should_write_context_value_through_to_vars()
+    {
+        var vars = CreateVars();
+
+        const string script = @"
+                ctx.number = ctx.number * 2;
+            ";
+
+        sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(26.0, vars["number"]);
+    }
+
+    [Fact]
+    public void Should_delete_context_value()
+    {
+        var vars = CreateVars();
+
+        const string script = @"
+                delete ctx.text;
+                Object.keys(ctx).join(',');
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("number,json,user"), actual);
+    }
+
+    private static ScriptVars CreateVars()
+    {
+        return new ScriptVars
+        {
+            ["number"] = 13,
+            ["text"] = "hello",
+            ["json"] = CreateJson(),
+            ["user"] = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                [
+                    new Claim(OpenIdClaims.Subject, "user1"),
+                    new Claim(OpenIdClaims.Name, "user"),
+                ], "Squidex")),
+        };
+    }
+
+    private static JsonValue CreateJson()
+    {
+        return JsonValue.Create(
+            new JsonObject()
+                .Add("name", JsonValue.Create("squidex"))
+                .Add("count", JsonValue.Create(3))
+                .Add("nested", JsonValue.Create(new JsonObject().Add("flag", JsonValue.True)))
+                .Add("items", JsonValue.Create(new JsonArray().Add(JsonValue.Create(1)).Add(JsonValue.Create(2)))));
+    }
 }

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JintScriptEngineTests.cs
@@ -1047,6 +1047,153 @@ public class JintScriptEngineTests : IClassFixture<TranslationsFixture>
         Assert.Equal(JsonValue.Create("number,json,user"), actual);
     }
 
+    [Fact]
+    public void Should_not_map_unread_variable()
+    {
+        var principal = new CountingPrincipal();
+
+        var vars = new ScriptVars
+        {
+            ["number"] = 13,
+            ["user"] = principal,
+        };
+
+        const string script = @"
+                number + 1;
+            ";
+
+        var actual = sut.Execute(vars, script);
+
+        Assert.Equal(JsonValue.Create(14), actual);
+        Assert.Equal(0, principal.Reads);
+    }
+
+    [Fact]
+    public void Should_see_unread_variable_in_enumeration()
+    {
+        var principal = new CountingPrincipal();
+
+        var vars = new ScriptVars
+        {
+            ["user"] = principal,
+        };
+
+        const string script = @"
+                ('user' in globalThis) + ',' + (Object.getOwnPropertyNames(globalThis).indexOf('user') >= 0);
+            ";
+
+        var actual = sut.Execute(vars, script);
+
+        Assert.Equal(JsonValue.Create("true,true"), actual);
+        Assert.Equal(0, principal.Reads);
+    }
+
+    [Fact]
+    public void Should_map_variable_on_first_read()
+    {
+        var principal = new CountingPrincipal();
+
+        var vars = new ScriptVars
+        {
+            ["user"] = principal,
+        };
+
+        const string script = @"
+                user.id;
+            ";
+
+        var actual = sut.Execute(vars, script);
+
+        Assert.Equal(JsonValue.Create("user1"), actual);
+        Assert.True(principal.Reads > 0);
+    }
+
+    [Fact]
+    public void Should_not_map_unread_context_variable()
+    {
+        var principal = new CountingPrincipal();
+
+        var vars = new ScriptVars
+        {
+            ["number"] = 13,
+            ["user"] = principal,
+        };
+
+        const string script = @"
+                ctx.number + 1;
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create(14), actual);
+        Assert.Equal(0, principal.Reads);
+    }
+
+    [Fact]
+    public void Should_see_unread_context_variable_in_enumeration()
+    {
+        var principal = new CountingPrincipal();
+
+        var vars = new ScriptVars
+        {
+            ["number"] = 13,
+            ["user"] = principal,
+        };
+
+        const string script = @"
+                Object.keys(ctx).join(',') + '|' + ('user' in ctx);
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("number,user|true"), actual);
+        Assert.Equal(0, principal.Reads);
+    }
+
+    [Fact]
+    public void Should_map_context_variable_on_first_read()
+    {
+        var principal = new CountingPrincipal();
+
+        var vars = new ScriptVars
+        {
+            ["user"] = principal,
+        };
+
+        const string script = @"
+                ctx.user.id;
+            ";
+
+        var actual = sut.Execute(vars, script, new ScriptOptions { AsContext = true });
+
+        Assert.Equal(JsonValue.Create("user1"), actual);
+        Assert.True(principal.Reads > 0);
+    }
+
+    private sealed class CountingPrincipal : ClaimsPrincipal
+    {
+        public int Reads { get; private set; }
+
+        public CountingPrincipal()
+            : base(new ClaimsIdentity(
+            [
+                new Claim(OpenIdClaims.Subject, "user1"),
+                new Claim(OpenIdClaims.Name, "user"),
+            ], "Squidex"))
+        {
+        }
+
+        public override IEnumerable<Claim> Claims
+        {
+            get
+            {
+                Reads++;
+
+                return base.Claims;
+            }
+        }
+    }
+
     private static ScriptVars CreateVars()
     {
         return new ScriptVars

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JsonMapperTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JsonMapperTests.cs
@@ -22,10 +22,9 @@ public class JsonMapperTests
         var mapped = (ObjectInstance)JsonMapper.Map(CreateJson(), engine);
         var nested = (ObjectInstance)mapped.Get("nested");
 
-        // A shared shape is what keeps a script reading a batch of content items monomorphic. It is a
-        // performance property and never a correctness one, but it is silent when it regresses: building
-        // these objects as a host ObjectInstance subclass again would put them back in the per-object
-        // dictionary with no test noticing.
+        // Sharing the layout is what makes reading properties of many content items fast. It only affects
+        // performance and never behavior, which is why it is asserted here: building these objects with a
+        // custom ObjectInstance class again would silently undo it and no other test would notice.
         Assert.True(engine.Advanced.HasSharedShape(mapped));
         Assert.True(engine.Advanced.HasSharedShape(nested));
     }

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JsonMapperTests.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/JsonMapperTests.cs
@@ -1,0 +1,53 @@
+// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using Jint;
+using Jint.Native.Object;
+using Squidex.Domain.Apps.Core.Scripting.Internal;
+using Squidex.Infrastructure.Json.Objects;
+
+namespace Squidex.Domain.Apps.Core.Operations.Scripting;
+
+public class JsonMapperTests
+{
+    [Fact]
+    public void Should_map_json_objects_into_a_shared_shape()
+    {
+        var engine = new Engine(o => o.Strict());
+
+        var mapped = (ObjectInstance)JsonMapper.Map(CreateJson(), engine);
+        var nested = (ObjectInstance)mapped.Get("nested");
+
+        // A shared shape is what keeps a script reading a batch of content items monomorphic. It is a
+        // performance property and never a correctness one, but it is silent when it regresses: building
+        // these objects as a host ObjectInstance subclass again would put them back in the per-object
+        // dictionary with no test noticing.
+        Assert.True(engine.Advanced.HasSharedShape(mapped));
+        Assert.True(engine.Advanced.HasSharedShape(nested));
+    }
+
+    [Fact]
+    public void Should_share_the_shape_between_objects_of_the_same_shape()
+    {
+        var engine = new Engine(o => o.Strict());
+
+        var first = (ObjectInstance)JsonMapper.Map(CreateJson(), engine);
+        var second = (ObjectInstance)JsonMapper.Map(CreateJson(), engine);
+
+        Assert.True(engine.Advanced.HasSharedShape(first));
+        Assert.True(engine.Advanced.HasSharedShape(second));
+    }
+
+    private static JsonValue CreateJson()
+    {
+        return JsonValue.Create(
+            new JsonObject()
+                .Add("name", JsonValue.Create("squidex"))
+                .Add("count", JsonValue.Create(3))
+                .Add("nested", JsonValue.Create(new JsonObject().Add("flag", JsonValue.True))));
+    }
+}

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/TestHelpers/JintHostContractVerification.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/TestHelpers/JintHostContractVerification.cs
@@ -1,0 +1,35 @@
+// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System.Runtime.CompilerServices;
+
+namespace Squidex.Domain.Apps.Core.TestHelpers;
+
+/// <summary>
+/// Turns on Jint's host-contract verifiers for this test assembly.
+/// </summary>
+/// <remarks>
+/// The scripting integration defines several Jint extension points - the ContentWrapper objects override
+/// GetOwnProperty and ProbeOwnProperty, and the engine trusts both without re-verifying them on the hot
+/// path. A hook that contradicts another therefore fails silently in production: a key vanishes from every
+/// enumeration, or a read resolves on the prototype for a property that exists. With the switch on, Jint
+/// recomputes the answer the fast paths exist to avoid and throws on the first disagreement, so these tests
+/// are the checker.
+/// <para>
+/// It has to be set before the first use of any Jint type - the flag is read once at type initialization -
+/// which is what the module initializer guarantees. Never turn it on in production: the verifiers
+/// deliberately redo the work they check.
+/// </para>
+/// </remarks>
+internal static class JintHostContractVerification
+{
+    [ModuleInitializer]
+    internal static void Enable()
+    {
+        AppContext.SetSwitch("Jint.EnableHostContractVerification", true);
+    }
+}

--- a/backend/tests/Squidex.Domain.Apps.Core.Tests/TestHelpers/JintHostContractVerification.cs
+++ b/backend/tests/Squidex.Domain.Apps.Core.Tests/TestHelpers/JintHostContractVerification.cs
@@ -10,19 +10,17 @@ using System.Runtime.CompilerServices;
 namespace Squidex.Domain.Apps.Core.TestHelpers;
 
 /// <summary>
-/// Turns on Jint's host-contract verifiers for this test assembly.
+/// Turns on Jint's self checks for this test assembly.
 /// </summary>
 /// <remarks>
-/// The scripting integration defines several Jint extension points - the ContentWrapper objects override
-/// GetOwnProperty and ProbeOwnProperty, and the engine trusts both without re-verifying them on the hot
-/// path. A hook that contradicts another therefore fails silently in production: a key vanishes from every
-/// enumeration, or a read resolves on the prototype for a property that exists. With the switch on, Jint
-/// recomputes the answer the fast paths exist to avoid and throws on the first disagreement, so these tests
-/// are the checker.
+/// Our ContentWrapper classes and the object converter implement Jint extension points where Jint relies on
+/// our answers being consistent, without checking them - checking would cost as much as the shortcut saves.
+/// A mistake there is silent in production: a key can disappear from Object.keys, or a converted type can be
+/// skipped. With this switch on Jint verifies the answers and throws on the first mismatch, so a mistake
+/// fails a test instead.
 /// <para>
-/// It has to be set before the first use of any Jint type - the flag is read once at type initialization -
-/// which is what the module initializer guarantees. Never turn it on in production: the verifiers
-/// deliberately redo the work they check.
+/// The switch has to be set before the first Jint type is used, which is what the module initializer
+/// guarantees. It stays off in production, where the checks would only cost performance.
 /// </para>
 /// </remarks>
 internal static class JintHostContractVerification


### PR DESCRIPTION
Upgrades Jint from **4.8.0 to 4.15.3**. There are two independent parts:

1. **The version bump** — one line in a `.csproj`. No source change needed, everything builds and all scripting tests pass unmodified. Scripts get **2–39% faster** on their own, depending on what they do.
2. **Six small changes** that tell the new Jint what our scripting integration actually needs. Jint has to be careful when we do not tell it, and we have been paying for that for years. This part adds another **35–50%** on the scenarios it aims at.

Scripts behave exactly the same in both parts — this PR is only about speed.

Sorry for the wall of engine jargon in the first version of this description. This one tries again.

## The terms I keep using

They come from how JavaScript engines are built (V8, SpiderMonkey, and by now Jint too):

**Inline cache.** When a script does `ctx.data.title.iv`, the engine remembers *at that exact spot in the script* where it found `title` last time, and reuses that on the next run instead of searching again. It can only do that when nothing is able to change the answer behind its back. If we register a hook and do not tell Jint what the hook is for, Jint has to assume the worst and switches these caches off — **for the whole engine**, not just for the objects we hooked. Two of our registrations did exactly that.

**Shape** (V8 calls it a *hidden class*). Objects that are created with the same keys can share one description of their layout, like a class, instead of every object carrying its own property dictionary. All content items of one schema have the same keys, so this applies to almost all JSON we push into scripts. A shared layout is cheaper to read from, and it is what makes the inline cache above possible in the first place. Objects built from a custom `ObjectInstance` subclass — which is how `JsonMapper` built them — can never take part in this.

**Host.** Jint's word for the application that embeds it, so: us. A *host contract* is a place where Jint calls into our code and then trusts the answer without verifying it, because verifying would cost as much as the shortcut saves. `ContentDataObject` and friends are such places.

## What the six changes are

| # | File | In one sentence |
| --- | --- | --- |
| 1 | `NullPropagation.cs` | Tell Jint that this resolver only reacts to null/undefined, so it can keep its read caches for everything else. |
| 2 | `JintObjectConverter.cs` | Tell Jint which .NET types this converter handles, so it does not have to offer it every property of every object. |
| 3 | `JsonMapper.cs` | Build JSON objects so they share their layout, instead of giving every object its own property dictionary. |
| 4 | `ContentFieldObject.cs` | Answer `'iv' in field` without converting the field value. |
| 5 | `WritableContext.cs`, `JintExtensions.cs` | Convert a script variable when it is first read, not when the engine is built. |
| 6 | tests only | Switch on Jint's own self-checks in the test suite, so a mistake in 1–5 fails a test instead of being silent. |

## Numbers

Measured on an idle machine with BenchmarkDotNet, strictly serial, three checkouts sharing an identical harness: **A** = `master` on 4.8.0, **B** = `master` with only the version line changed, **C** = this PR. Every scenario asserts its exact expected output before being measured, and all three arms produced the same outputs.

| Scenario | A: today | B: bump only | C: this PR | overall |
| --- | --- | --- | --- | --- |
| Plain arithmetic (control) | 86.1 μs | 52.6 μs | 54.7 μs | **−37%** |
| Trigger script | 7.6 μs | 6.1 μs | 6.1 μs | **−19%** |
| Content transform | 16.5 μs | 14.2 μs | 14.8 μs | **−10%** |
| `JSON.stringify(data)` | 11.3 μs | 9.4 μs | 9.2 μs | **−19%** |
| Walking a JSON object *(change 3)* | 55.2 μs | 52.4 μs | 32.4 μs | **−41%** |
| Many variables, few read, `ctx` *(change 5)* | 12.9 μs | 12.6 μs | 6.7 μs | **−48%** |
| Many variables, few read, globals *(change 5)* | 12.6 μs | 11.3 μs | 5.6 μs | **−55%** |
| Many .NET property reads *(changes 1+2)* | 108.9 μs | 85.0 μs | 55.0 μs | **−50%** |

Two things worth being honest about:

- The control row moves a lot between A and B, so it is a *result* of the upgrade, not a measurement floor. The floor for judging part 2 is the B→C control pair (same engine, same harness): **±4%**. The four rows above that clearly beat it are the ones I claim as wins; the small ones sit inside it and I do not claim they moved.
- Change 5 has a real cost on the other side: on a script with a handful of cheap variables it *adds* ~2–3 KB per evaluation for the deferred-conversion bookkeeping (the trigger row). It pays that back many times as soon as variables are numerous or expensive. That is the trade it is designed to make.

Allocations are down in every scenario compared to today.

## The changes in detail

### 1. Tell Jint what `NullPropagation` does

`SetReferencesResolver` without a second argument means "this resolver might react to anything", and Jint answers by disabling its member-read caches engine-wide, for every property read in every script.

`NullPropagation.TryPropertyReference` returns `false` for everything that is not null or undefined, so for the other cases Jint asking us can never change the result. Declaring that re-enables the caches:

```csharp
engineOptions.SetReferencesResolver(NullPropagation.Instance, NullPropagation.Interests);
```

Jint documents this list as a subscription filter and not a promise: for a case we do not subscribe to, it behaves as if no resolver was registered at all — which is what it would have done anyway.

<details>
<summary>Why not the built-in <code>NullPropagatingReferenceResolver</code> that 4.15 ships?</summary>

Because it is not the same behavior. It does not answer unresolvable names or non-callable members, where our resolver does, so swapping it in would turn `unknownName` and `ctx.value.notAFunction()` into errors for existing scripts. Two tests pin that difference.

One oddity found on the way and left alone: our `TryUnresolvableReference` passes the reference base straight through, and for an unknown name that base is an internal Jint marker string reading `[[Unresolvable]]`, not `undefined`. So `String(unknownName)` has always been `"[[Unresolvable]]"` here. Changing it to `undefined` would be tidier but is a behavior change for existing scripts, so it is only documented and pinned by a test.
</details>

### 2. Tell Jint which types `JintObjectConverter` handles

Same shape of problem: a converter that has not declared its types might be handed anything, so Jint has to offer it every .NET property read and cannot use its compiled property reader for any of them. The converter handles a closed set of nine types, now declared as `JintObjectConverter.HandledTypes` and kept directly above the `switch` it must match.

Matching is by assignability, so `typeof(IUser)` still covers every implementation, and the filter errs towards claiming — the converter is still offered every value it was offered before.

The `Enum` case is dropped in favor of `Interop.EnumConversion = EnumConversionMode.String`, which Jint documents as the member name as produced by `ToString()` — including `"ContentScript, Transform"` for a `[Flags]` combination and the number as a string for a value with no name. Same output as the branch it replaces, tests for all three cases.

The obvious risk is that someone adds a `case` here and forgets the list. That is not silent: change 6 makes it fail a test by name (verified by deliberately breaking it).

### 3. Let `JsonMapper` build shared-layout objects

`JsonMapper` built every JSON object as a private `ObjectInstance` subclass that existed only to be instantiable — and such an object can never share a layout, so all of `ctx.data`'s leaf objects and every JSON variable were permanently on the slow path.

`JsObject.CreateFromEntries` builds the same object the way Jint builds an object literal — same keys, same order, same flags, indistinguishable from a script — but through the layout machinery, so repeated calls with the same key sequence share one layout. That is the JSON walk row above (−38% of it from this change alone).

Jint falls back to the per-object dictionary silently when it cannot build the shared form, so `JsonMapperTests` asserts it actually happened (`HasSharedShape`) rather than assuming it.

Three unrelated small fixes in the same file: the reverse direction allocated a string per array element (`a.Get(i.ToString())`) where the indexer reads the array storage directly, and `JsNumber.Create`/`JsString.Create` reuse cached instances where `new` always allocated.

### 4. `ContentFieldObject` answers existence questions without converting

`ContentFieldProperty` converts the stored `JsonValue` on first read. Questions like `'iv' in field`, `hasOwnProperty`, `Object.keys`, spread and `JSON.stringify` do not need the value at all, but used to pay for it, because they all went through `GetOwnProperty`. The new `ProbeOwnProperty` answers them from the property flags instead.

It is deliberately a copy of `GetOwnProperty` minus the value, because Jint trusts it without checking — a wrong answer would silently drop keys from every enumeration above. Change 6 is what checks it.

`ContentDataObject` deliberately does **not** get the same treatment; see below.

### 5. Convert script variables on first read

Every variable was converted when the engine was set up, whether the script mentioned it or not — and some are not cheap (the user variable walks and groups all claims). A typical script uses two or three of them.

Both paths now defer that, with the two APIs 4.15 added for it:

```csharp
// ctx.* — WritableContext
SetOwnProperty(key, PropertyDescriptor.CreateLazy(...));

// globals — JintExtensions
engine.Advanced.AddLazyGlobal(key, e => MapVariable(e, item));
```

The property itself is added immediately in both cases, so key order, `Object.keys`, `in`, `getOwnPropertyNames`, `delete` and the write-through to `ScriptVars` are unchanged — only the conversion waits. `MapVariable` reproduces what `Engine.SetValue` does, including its special case for a `Type`, so a deferred variable cannot look different from an eager one. Six tests use a `ClaimsPrincipal` that counts how often its claims are read to prove all three properties: not converted when unread, still visible in enumeration, converted on first read.

<details>
<summary>One edge case worth recording</summary>

`Engine.SetValue` assigns through the normal write path while `AddLazyGlobal` installs the property directly, so a variable named exactly like a non-writable built-in (`undefined`, `NaN`, `Infinity`) would now shadow it where it was silently ignored before. `ScriptVars` keys are domain names, so this cannot happen in practice.
</details>

### 6. Jint's self-checks run in the test suite

Changes 1, 2 and 4 all have the same failure mode: we tell Jint something, Jint believes us without checking, and if we are wrong nothing throws — a key just disappears from `Object.keys`, or a type stops being converted.

4.15 can turn those checks on in the shipped release package through an `AppContext` switch (before, this needed a source build of Jint in Debug). A module initializer in the test assembly sets it, so **every CI run** verifies our extension points against the same NuGet package production uses, and a violation is an ordinary test failure. It stays off in production, where the checks would only cost performance.

Both checks were confirmed by deliberately breaking them first:

- a wrong `ProbeOwnProperty` fails with *"ContentFieldObject.ProbeOwnProperty answered 'iv' with Missing but its GetOwnProperty reports Enumerable"*;
- an undeclared converter type fails with *"JintObjectConverter converted a value of type System.Version, which is not among the types it was registered as handling"*.

With both correct, all 1279 tests in `Squidex.Domain.Apps.Core.Tests` pass with the checks on.

## What I deliberately did not do

- **Engine pooling.** This is the biggest remaining win — an engine is built per evaluation, and Jint's per-script caches only pay off from the second evaluation *on the same engine*. It is not safe today, and the reason is on our side, not Jint's: `ScriptExecutionContext`'s scheduler re-enters the engine from task continuations under `lock (Engine)`, guarded only by `IsCompleted`, and on timeout `WaitForCompletionAsync` returns while the `TaskCompletionSource` is neither completed nor faulted — so a late `scheduler.Run` **can** re-enter the engine afterwards. Today that engine is garbage and nobody notices. Pooled, it would write one evaluation's data into the next one's variables. That needs a kill flag in the scheduler first, and is its own PR.
- **`ContentDataObject.GetOwnProperty` creating a field for any name it is asked about.** Pre-existing and visible to scripts (`data.hasOwnProperty` reads as a field rather than the function, and asking about a name makes it show up in `Object.keys`). Not this PR's business — but it is also the reason `ContentDataObject` gets no `ProbeOwnProperty` in change 4: to stay consistent with that `GetOwnProperty`, the probe would have to create phantom fields too.
- **`Options.AddImmutableCrossing`** (new in 4.15, lets Jint cache reads of .NET objects a host promises will not change while scripts can see them). Does not fit: `ScriptVars` is written through by design and `AssetMetadata` is mutated by scripts on purpose, there is a test for it. It is also an options-time setting, and the types that would be candidates live in `Squidex.Domain.Apps.Entities`, which the engine setup cannot reference. A wrong promise here means stale reads, so this is not a place to guess.
- **Removing `SetTypeConverter`.** It is needed (extension delegates take `JsonValue` parameters). Worth recording that it costs something: with a custom type converter installed, Jint excludes indexer accessors from its shared cross-engine cache. If that ever shows up in a profile, the fix is a shared `TypeResolver` for all Squidex engines, not removing the converter.

## Tests

`backend/tests/Squidex.Domain.Apps.Core.Tests/Operations/Scripting/` goes from **128 to 164 tests**.

Everything behavior-adjacent was pinned *before* the change and run green on the old code first: the first commit adds 28 tests and passes on Jint 4.8.0, which is bisectable. They cover undeclared names, null-propagating chains, calls on non-callable members, ordinary reads and calls, enum conversion including `[Flags]`, JSON object key order / `stringify` / `for..in` / mutation / round trip, content fields under `in` / `hasOwnProperty` / `propertyIsEnumerable` / `Object.keys` / spread / `stringify` (also after a delete and an add), and the context object's enumeration, `typeof`, write-through and `delete`.

The remaining 8 arrive with the features they describe and are red before the change, green after.

<details>
<summary>Verification runs</summary>

Run with the same commands CI uses (`Dockerfile`: `dotnet test --filter "Category!=Dependencies & Category!=TestContainer" --configuration Release`), so Meziantou.Analyzer and StyleCop ran in-build. One StyleCop diagnostic was introduced and fixed properly (SA1203); no suppressions added.

- Full backend solution build in Release: succeeds. The 35 warnings are all pre-existing and in untouched projects.
- `Squidex.Domain.Apps.Core.Tests` **1279/1279**, including all 164 scripting tests, with Jint's self-checks on.
- `Squidex.Infrastructure.Tests` 1073/1073 · `Squidex.Domain.Users.Tests` 57/57 · `Squidex.Web.Tests` 167/167.
- `Squidex.Domain.Apps.Entities.Tests` 1524/1526 — the two failures are `FFMpegAssetMetadataSourceTests`, which need the `ffmpeg` binary that the CI image has and my machine does not. They touch no scripting code.

The first eight commits are logical units and each builds and passes on its own. The ninth rewrites the code comments in plainer language after review feedback and changes nothing else — it is deliberately a separate commit rather than folded into the others, so that a review already in progress stays valid.
</details>

<details>
<summary>Compatibility notes</summary>

**Everything Squidex touches was verified present and unchanged across 4.8 → 4.15:** `ObjectInstance.Extensible` is still `public virtual`; `GetOwnProperty`, `Set`, `DefineOwnProperty`, `RemoveOwnProperty`, `GetOwnProperties`, `GetOwnPropertyKeys` signatures unchanged; `PropertyDescriptor(PropertyFlag)` and `protected virtual CustomValue` unchanged, so `CustomProperty` and `ContentFieldProperty` behave as before; `Engine.Constraints.Reset()`, `Options.Constraints.PromiseTimeout`, `AllowClrWrite`, `EvaluateAsync(in Prepared<Script>, CancellationToken)`, `CancellationToken(ct)`, `ObjectWrapper.Create`, `JsDate(engine, DateTime)`, `JsValue.FromObject` all present; the `JsArray`/`JsString` pattern matches in `JintExtensions.ToIds` and `ScriptOperations.Reject` are unaffected.

**Transitive dependency:** Acornima moves to 1.6.2. `ParseErrorException`, `ScriptPreparationException` and `JintException`, which `JintScriptEngine.MapException` switches on, all still exist.

**Constraints need no change.** `TimeoutInterval` and `CancellationToken` are the kind that keeps Jint's interpreter fast path armed.

**Package provenance.** After restore, `.nupkg.metadata` reports `https://api.nuget.org/v3/index.json` and the nuspec repository commit is `a304aa5dacd340e2a5ff51e1ea0c465e38e50aa8`, the v4.15.3 tag.

**Also unchanged and already right:** `Prepared<Script>` is cached via `CacheParser` and shared across engines (Jint documents that as safe), and `Strict()` is on.

The branch is still named 4.15.2 because renaming it would close this PR; the pinned version is 4.15.3.
</details>
